### PR TITLE
WAZE traffic jam outlier detection

### DIFF
--- a/dags/waze/Outlier-Detection-WAZE-Traffic-Jam-by-Delay.ipynb
+++ b/dags/waze/Outlier-Detection-WAZE-Traffic-Jam-by-Delay.ipynb
@@ -1,0 +1,1480 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 308,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from sqlalchemy import create_engine\n",
+    "from mapboxgl.viz import LinestringViz\n",
+    "from mapboxgl.utils import create_color_stops, create_numeric_stops\n",
+    "from geojson import Feature, FeatureCollection, LineString\n",
+    "\n",
+    "#categoried by road_types. from 10mil rows of data, outlier upperbounds -- mean+2std:\n",
+    "upperbound_delay_rt1_2std = 364.2580985017166 \n",
+    "upperbound_delay_rt2_2std = 416.00629003480043\n",
+    "upperbound_delay_rt3_2std = 1337.7260891639444\n",
+    "upperbound_delay_rt4_2std = 393.1583664937325\n",
+    "upperbound_delay_rt6_2std = 494.9713645058797\n",
+    "upperbound_delay_rt7_2std = 366.12815975980857\n",
+    "upperbound_delay_rt17_2std = -1.0\n",
+    "upperbound_delay_rt20_2std = -1.0"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mapbox token\n",
+    "token = os.getenv('MAPBOX_ACCESS_TOKEN')\n",
+    "\n",
+    "# Postgres Database login info\n",
+    "USER = os.getenv('WAZE_USER')\n",
+    "PASS = os.getenv('WAZE_PASS')\n",
+    "HOST = 'datalake.cyuk6whwgqww.us-west-2.rds.amazonaws.com'\n",
+    "PORT = '5432'\n",
+    "DB = 'db_datalake'\n",
+    "\n",
+    "uri = 'postgresql://{}:{}@{}:{}/{}'.format(USER, PASS, HOST, PORT, DB)\n",
+    "engine = create_engine(uri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_datafiles = pd.read_sql_query(\"select * from waze.data_files;\", con=engine)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_csv('waze_jams_10mil.csv')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 665,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>start_time_millis</th>\n",
+       "      <th>end_time_millis</th>\n",
+       "      <th>start_time</th>\n",
+       "      <th>end_time</th>\n",
+       "      <th>date_created</th>\n",
+       "      <th>date_updated</th>\n",
+       "      <th>file_name</th>\n",
+       "      <th>json_hash</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>1513033380000</td>\n",
+       "      <td>1513033440000</td>\n",
+       "      <td>2017-12-11 23:03:00</td>\n",
+       "      <td>2017-12-11 23:04:00</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>wazedata_2017_12_11_23_06_03_062.json</td>\n",
+       "      <td>367f73e1e1f190bc817499e550575824</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>1513033500000</td>\n",
+       "      <td>1513033560000</td>\n",
+       "      <td>2017-12-11 23:05:00</td>\n",
+       "      <td>2017-12-11 23:06:00</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>wazedata_2017_12_11_23_08_02_202.json</td>\n",
+       "      <td>7063d4be9abff1f0958d07811f0a7b0b</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>3</td>\n",
+       "      <td>1513033620000</td>\n",
+       "      <td>1513033680000</td>\n",
+       "      <td>2017-12-11 23:07:00</td>\n",
+       "      <td>2017-12-11 23:08:00</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>wazedata_2017_12_11_23_10_01_621.json</td>\n",
+       "      <td>5e5d4e897f7b09d856501fbd6fb850d7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>4</td>\n",
+       "      <td>1513033740000</td>\n",
+       "      <td>1513033800000</td>\n",
+       "      <td>2017-12-11 23:09:00</td>\n",
+       "      <td>2017-12-11 23:10:00</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>wazedata_2017_12_11_23_12_01_862.json</td>\n",
+       "      <td>fef7efe233322d955327b2355e8a5e28</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>5</td>\n",
+       "      <td>1513033860000</td>\n",
+       "      <td>1513033920000</td>\n",
+       "      <td>2017-12-11 23:11:00</td>\n",
+       "      <td>2017-12-11 23:12:00</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>2018-06-12</td>\n",
+       "      <td>wazedata_2017_12_11_23_14_01_742.json</td>\n",
+       "      <td>1247d10314b085dcd3a9c0e527e608f8</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   id  start_time_millis  end_time_millis          start_time  \\\n",
+       "0   1      1513033380000    1513033440000 2017-12-11 23:03:00   \n",
+       "1   2      1513033500000    1513033560000 2017-12-11 23:05:00   \n",
+       "2   3      1513033620000    1513033680000 2017-12-11 23:07:00   \n",
+       "3   4      1513033740000    1513033800000 2017-12-11 23:09:00   \n",
+       "4   5      1513033860000    1513033920000 2017-12-11 23:11:00   \n",
+       "\n",
+       "             end_time date_created date_updated  \\\n",
+       "0 2017-12-11 23:04:00   2018-06-12   2018-06-12   \n",
+       "1 2017-12-11 23:06:00   2018-06-12   2018-06-12   \n",
+       "2 2017-12-11 23:08:00   2018-06-12   2018-06-12   \n",
+       "3 2017-12-11 23:10:00   2018-06-12   2018-06-12   \n",
+       "4 2017-12-11 23:12:00   2018-06-12   2018-06-12   \n",
+       "\n",
+       "                               file_name                         json_hash  \n",
+       "0  wazedata_2017_12_11_23_06_03_062.json  367f73e1e1f190bc817499e550575824  \n",
+       "1  wazedata_2017_12_11_23_08_02_202.json  7063d4be9abff1f0958d07811f0a7b0b  \n",
+       "2  wazedata_2017_12_11_23_10_01_621.json  5e5d4e897f7b09d856501fbd6fb850d7  \n",
+       "3  wazedata_2017_12_11_23_12_01_862.json  fef7efe233322d955327b2355e8a5e28  \n",
+       "4  wazedata_2017_12_11_23_14_01_742.json  1247d10314b085dcd3a9c0e527e608f8  "
+      ]
+     },
+     "execution_count": 665,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_datafiles.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 666,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>uuid</th>\n",
+       "      <th>pub_millis</th>\n",
+       "      <th>pub_utc_date</th>\n",
+       "      <th>start_node</th>\n",
+       "      <th>end_node</th>\n",
+       "      <th>road_type</th>\n",
+       "      <th>street</th>\n",
+       "      <th>city</th>\n",
+       "      <th>country</th>\n",
+       "      <th>...</th>\n",
+       "      <th>speed_kmh</th>\n",
+       "      <th>length</th>\n",
+       "      <th>turn_type</th>\n",
+       "      <th>level</th>\n",
+       "      <th>blocking_alert_id</th>\n",
+       "      <th>line</th>\n",
+       "      <th>type</th>\n",
+       "      <th>turn_line</th>\n",
+       "      <th>datafile_id</th>\n",
+       "      <th>pid</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1512561891461</td>\n",
+       "      <td>2017-12-06 12:04:51.461</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>S Hope St</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Hope St</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>US</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>250</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4fcf81c4-0e54-323b-9e31-4e9289b92788</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>501</td>\n",
+       "      <td>194017</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1512561891461</td>\n",
+       "      <td>2017-12-06 12:04:51.461</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>S Hope St</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Hope St</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>US</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>250</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4fcf81c4-0e54-323b-9e31-4e9289b92788</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>531318</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1512561891461</td>\n",
+       "      <td>2017-12-06 12:04:51.461</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>S Hope St</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Hope St</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>US</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>250</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4fcf81c4-0e54-323b-9e31-4e9289b92788</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>154</td>\n",
+       "      <td>144247</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1512561891461</td>\n",
+       "      <td>2017-12-06 12:04:51.461</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>S Hope St</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Hope St</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>US</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>250</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4fcf81c4-0e54-323b-9e31-4e9289b92788</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>309</td>\n",
+       "      <td>165476</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>1512561891461</td>\n",
+       "      <td>2017-12-06 12:04:51.461</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>S Hope St</td>\n",
+       "      <td>7</td>\n",
+       "      <td>Hope St</td>\n",
+       "      <td>Los Angeles, CA</td>\n",
+       "      <td>US</td>\n",
+       "      <td>...</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>250</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>5</td>\n",
+       "      <td>4fcf81c4-0e54-323b-9e31-4e9289b92788</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>NONE</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>51</td>\n",
+       "      <td>44394</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 22 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "           id        uuid     pub_millis             pub_utc_date start_node  \\\n",
+       "0  1866670844  1866670844  1512561891461  2017-12-06 12:04:51.461        NaN   \n",
+       "1  1866670844  1866670844  1512561891461  2017-12-06 12:04:51.461        NaN   \n",
+       "2  1866670844  1866670844  1512561891461  2017-12-06 12:04:51.461        NaN   \n",
+       "3  1866670844  1866670844  1512561891461  2017-12-06 12:04:51.461        NaN   \n",
+       "4  1866670844  1866670844  1512561891461  2017-12-06 12:04:51.461        NaN   \n",
+       "\n",
+       "    end_node  road_type   street             city country   ...    speed_kmh  \\\n",
+       "0  S Hope St          7  Hope St  Los Angeles, CA      US   ...          NaN   \n",
+       "1  S Hope St          7  Hope St  Los Angeles, CA      US   ...          NaN   \n",
+       "2  S Hope St          7  Hope St  Los Angeles, CA      US   ...          NaN   \n",
+       "3  S Hope St          7  Hope St  Los Angeles, CA      US   ...          NaN   \n",
+       "4  S Hope St          7  Hope St  Los Angeles, CA      US   ...          NaN   \n",
+       "\n",
+       "   length  turn_type  level                     blocking_alert_id  \\\n",
+       "0     250       NONE      5  4fcf81c4-0e54-323b-9e31-4e9289b92788   \n",
+       "1     250       NONE      5  4fcf81c4-0e54-323b-9e31-4e9289b92788   \n",
+       "2     250       NONE      5  4fcf81c4-0e54-323b-9e31-4e9289b92788   \n",
+       "3     250       NONE      5  4fcf81c4-0e54-323b-9e31-4e9289b92788   \n",
+       "4     250       NONE      5  4fcf81c4-0e54-323b-9e31-4e9289b92788   \n",
+       "\n",
+       "                                                line  type turn_line  \\\n",
+       "0  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...  NONE       NaN   \n",
+       "1  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...  NONE       NaN   \n",
+       "2  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...  NONE       NaN   \n",
+       "3  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...  NONE       NaN   \n",
+       "4  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...  NONE       NaN   \n",
+       "\n",
+       "  datafile_id     pid  \n",
+       "0         501  194017  \n",
+       "1        1000  531318  \n",
+       "2         154  144247  \n",
+       "3         309  165476  \n",
+       "4          51   44394  \n",
+       "\n",
+       "[5 rows x 22 columns]"
+      ]
+     },
+     "execution_count": 666,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 668,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_datafiles=df_datafiles[['id', 'start_time', 'end_time']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Check LA city ONLY"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = df[df.city == 'Los Angeles, CA']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "checking some info & drop unnecessary columns"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 669,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time = pd.merge(df[['id', 'datafile_id', 'street', 'road_type', 'delay', 'length', 'line']], df_datafiles, left_on='datafile_id', right_on='id')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 670,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time.drop(columns=['id_y'], inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 671,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time.rename({'id_x':'jam_id'}, axis='columns', inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 672,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Verify the time zone"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 673,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "datetime.datetime(2017, 12, 12, 0, 0, tzinfo=<DstTzInfo 'US/Pacific' LMT-1 day, 16:07:00 STD>)"
+      ]
+     },
+     "execution_count": 673,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datetime(2017,12,12,0,0,0,tzinfo=timezone('US/Pacific'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 674,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3cAAAGDCAYAAACIr+kwAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJzs3XmYJGldL/rvGxG51t5V1dVL9Uz3zHTPMBsj08wgPDAIyoCocNUj4AIoV47bdUHx4PVcUTge9egVr8tBkcVBOYBwVZA7AwzbIAOzM2vPdE/vW3XXvuQey3v/iHgjI7MyKyMyqyq37+d55pmqrMjO6O7qivzFbxNSShAREREREVF309p9AkRERERERNQ6BndEREREREQ9gMEdERERERFRD2BwR0RERERE1AMY3BEREREREfUABndEREREREQ9gMEdERERERFRD2BwR0RERERE1AMY3BEREREREfUAo90nsJGJiQm5f//+dp8GERERERFRWzz66KPzUsrJMMd2dHC3f/9+PPLII+0+DSIiIiIiorYQQpwJeyzLMomIiIiIiHoAgzsiIiIiIqIewOCOiIiIiIioBzC4IyIiIiIi6gEM7oiIiIiIiHoAgzsiIiIiIqIewOCOiIiIiIioBzC4IyIiIiIi6gEM7oiIiIiIiHoAgzsiIiIiIqIewOCOiIiIiIioBzC4IyIiIiIi6gEM7qgmx5F4z//7JJ6+sNLuUyEiIiIiohAY3FFNy3kTn3r4HO47NtfuUyEiIiIiohAY3FFN2aIFACiYdpvPhIiIiIiIwmBw1wc++dBZ3P3UTKTnZEtucJcvMbgjIiIiIuoGRrtPgLbe7/zLUwCA03/8+tDPyRbdoC7HzB0RERERUVdg5o5qynmZuwIzd0REREREXYHBHdWkeu7yzNwREREREXUFBnd9REoZ+li/LJOZOyIiIiKirsDgro9kvGxcGKosk5k7IiIiIqLuwOCujyxmS6GPzXiZO07LJCIiIiLqDgzu+kiU4I6ZOyIiIiKi7sLgro9Ey9xxzx0RERERUTdhcNdHFqJk7lRZJjN3RERERERdgcFdH1nKlvDomUV8/omLDY/Nlpi5IyIiIiLqJgzuepzjlNcfLGZL+LEPfge/+snvNnxecM9doxUKJ+cy+JuvH2/tRImIiIiIqCUM7nqcFQjuZlYKoZ+XDWTsCqaz4bH3PH0Jf/qlo35ASERERERE24/BXY+znHJg9pVnL4d+XjBQa9R3p7KDlh1+SToREREREW2uhsGdEOKjQohZIcTTgcf+VAjxnBDiSSHEvwohRgNf+x0hxHEhxFEhxJ2Bx1/rPXZcCPGezf+tUC1mIODKReifCx6r1iLUo7KDJXvjDB8REREREW2dMJm7fwDw2qrH7gVwo5TyZgDHAPwOAAghrgfwZgA3eM/5n0IIXQihA/gbAK8DcD2At3jH0hazvIDrt197La6eHAAAGJpo+Lxs0cJgwgAAFBpl7ryePJPBHRERERFR2zQM7qSU3wSwWPXYl6WUKp3zAIBp7+M3APiUlLIopTwF4DiA27z/jkspT0opSwA+5R1LW8z2smrDyRi+8q478Cvfdw0sR1YMWqklW7QwMRgHAORLGwdt6jUY3BERERERtc9m9Nz9HIB7vI/3AjgX+Np577F6j68jhHinEOIRIcQjc3Nzm3B6/c30Aq+YLiCEQDqhA9i4hNJxJHKmjYnBBIDGZZk2M3dERERERG3XUnAnhPhdABaAT2zO6QBSyg9JKQ9LKQ9PTk5u1i/bt1RZpqG5f9Vx3f3/RsFdwbIhJTA55AZ3YQeqlCwOVCEiIiIiahej2ScKId4O4IcAvFqWF6FdALAvcNi09xg2eJy2kBqoYuhun13c8II7q35wl/EmZY57ZZmNeu7UQJXgZE4iIiIiItpeTWXuhBCvBfDbAH5ESpkLfOnzAN4shEgIIQ4AOAjgIQAPAzgohDgghIjDHbry+dZOncJQAVdMr8rcbRDcFb29dmNpN7hrNGXTYc8dEREREVHbNczcCSE+CeCVACaEEOcBvBfudMwEgHuFEADwgJTyF6SUzwgh/hnAEbjlmr8spbS9X+dXAHwJgA7go1LKZ7bg90NV1O453ZuQqYK8jQIxVbI5kooBaFyWqXruWJZJRERERNQ+DYM7KeVbajz8kQ2O/0MAf1jj8bsB3B3p7KhlVmCgChCuLFN9zQ/uGmTuVJzIzB0RERERUftsxrRM6mDrBqp4wV1xE4M7lmUSEREREbUfg7set26gSoSyzHTcgKGJhmWZFoM7IiIiIqK2Y3DX49YNVIlQlhnTBRKGtuGxAOConjubPXdERERERO3C4K7HqayaGqjiB3chMndxQ0Pc0DY8FgBslblrEAQSEREREdHWYXDX49S0zFjVEvMNyzKtcnCXMHR/NUI9alomyzKJiIiIiNqHwV2P8weq6JWrEMKUZSZCZu44UIWIiIiIqP0Y3PU4s84qhG8dn8cf/HvtVYPlnjsNCUND0Qo3UIU9d0RERERE7cPgrsepzJ3ulWUmvODu7qcu4WP3n/b75YLW9dw1Gqji/RoWM3dERERERG3D4K7HqayaoVWWZS7nSgCAXMla9xy/587P3LHnjoiIiIio0zG463H+QJWqVQgqYZersaDcrMrcNQzuWJZJRERERNR2DO56nNpzZ1T13CnZ4vrMXbF6WmbIPXfM3BERERERtQ+Dux5nVq1CUINVlFqZO3+gihau54577oiIiIiI2o/BXY/zB6qozJ1e+VdeM7izHcR0AU0ToaZl2lyFQERERETUdgzuelz1QBUhREWAl60zUEUdkzD00Jk79twREREREbUPg7seVz1QBajsu8vXGaiijgk1UEWWn0dERERERO3B4K7HWY4DIQBdK/faBfvuag1UKVnl4C5haCiaG5dlOizLJCIiIiJqOwZ3Pc60pT9MRQlm7uoNVInp5eCu1CBoY88dEREREVH7MbjrcZbtVGTtgMrgrlbPXdGuytxZDqSs30/n99xZ7LkjIiIiImoXBnc9znKkv+NOCfbf1eq5Cw5UiRsapCwPZqnF9gI/tVOPiIiIiIi2H4O7Hmc5TkUwB1SuQ8gWaw9USRjlaZkANhyqwp47IiIiIqL2Y3DX4yxb+msQlERFz93GA1XU/zdah6AydybLMomIiIiI2obBXY8zbbkucxer2HPXeKAKgA0XmZf33DFzR0RERETULgzuepzlbDxQJV8rc2dHzNyxLJOIiIiIqO0Y3PW4WgNVVMA2lDRq9twFB6qE6bljcEdERL0qW7Tw9o89hNPz2XafChFRQwzuepxlO+v23KmSy8mhxKb03Dmq585mzx0REfWWZ2dW8Y2jc3jkzFK7T4WIqCEGdz3Osutn7nYOJWr33FXtuQNC9txtEAASERF1o5mVAoDaA8iIiDoNg7seZzoSRtVAlYSfuUuG2nMHsCyTiIh63xefnsG1//UeLGSK/mOXV93gLlNkcEdEnc9o9wnQ1rJsZ90qhLihwdAExtIxZBsMVEmECO7UfnMGd0RE1M3+9bsXULQcvOufn4CuCXzgJ27BJZW5q9GjTkTUaRjc9TjLWb/nbjgVw46BONJxo+bFqlbmbqOSS8txv8aeOyIi6mZDyRgA4L5jcwCAe56ewQwzd0TURViW2eMs21m35+4X77ga//S/346BuI6S7aBkuf995pFzsB1ZMVAlzLRML7Zj5o6IiLrafKaIyaEEfus1h7BvRwr3PH0Jl9lzR0RdhJm7HldrFcLYQBxjA3E8cW4ZAHB2MYtnLq7i3Z99EpNDCViOXLfEfMM9d5I9d0RE1P3m1oq4cc8wfuVVB7FWsPDR+08hFXNvctYaQEZE1GmYuetxpi1haLX/mm/ZNwoA+O7ZZXz3rBvoPe4FfFGnZQrh9t6p4SpERETdRmXuAOAHb9oN05ZYLbgZuyzLMomoCzC463G1BqooV08OYihh4PFzy35Qp/6fqNpzVzRrZ+UcL5hLeuWbzN4REVE3chyJ+UwJE4NucHfz9Ah2eoEewIEqRNQdGNz1OLtGWaaiaQI37xvBw6cXceTiKgD4pZrVPXelOkGbpYK7mLbhcURERJ1sOW/CdqSfuRNC4Mdvnfa/nilauOepGSxmS+06RSKihhjc9bhsyULS6xeo5ZZ9ozh2OYOS7eDQ1CCWciYArN9zVy9zJ1Vw5wWBXGRORERdaG7N3W2nMncA8GvffxDv/eHrcecNU5hZyeMXP/EYfvrDD7brFImIGmJw18OWcyVcXi3i4M7Buse88Za9OHzlGPaPp/H2lx7wH1cDVXRNwNAESnbtchTVYzeUdGfzsGyFiIi60by3uHwyUIqZMHT87MsOYMdAwr/5eWRmtS3nR0QUBqdl9jB1Abp+z3DdYw5ODeGzv/hSAG6z+N/edwJnF3MYScX8YxKGVjdzpyZljg8kAGSwlCvhivH0Jv0OiIiItketzJ0ymKisgCmY9oZVMURE7cLgroepProX7K4f3AUNJAx87TfvwCNnlvDi/TsqHl8r1J4SpgaqjA/GAbg9C0RERN2mVuZOSccr3y49fm4ZL7lqfFvOi4goioZlmUKIjwohZoUQTwce2yGEuFcI8bz3/zHvcSGE+EshxHEhxJNCiBcFnvM27/jnhRBv25rfDgUdmVnF1HCi5l3Iegxdw0uuGocemLA5PpjAQp0GcjVQRb3Gco6N5kRE1H3m1oqI6xqGk+vvew8mKh979MzSdp0WEVEkYXru/gHAa6seew+Ar0opDwL4qvc5ALwOwEHvv3cC+CDgBoMA3gvgdgC3AXivCghp6xy5uIrrQ2btNjIxGMdCtljzaypzt2PAy9zlmLkjIqLuM+ftuBNi/YTptFeWmTA0jKZjuLRS2O7TIyIKpWFwJ6X8JoDFqoffAOAu7+O7ALwx8PjHpesBAKNCiN0A7gRwr5RyUUq5BOBerA8YaROdX8rh6OU13Hpl6zH0+EAcC5naGTnVczfmBXdLzNwREVEXcnfcxWt+TWXuJofcaph6NzyJiNqt2WmZU1LKGe/jSwCmvI/3AjgXOO6891i9x9cRQrxTCPGIEOKRubm5Jk+vd/3TA2dwy/u+DOkFVfX862MXICXwhltq/jFHMj6YwEKm9oVMTctMGBqGkgYzd0RE1JXm1oo1++2Acs/d5FAC4wNxzNe54UlE1G4tr0KQbpSxcaQR7df7kJTysJTy8OTk5Gb9sj3j9z73NJZzJoob7JNzHInPPnYe33vVOPbtaH1y5fhgHNmSjXxp/ZoDxzsNXQiMpmPsuSMioq40nynW7VEf8MoyJwe9zF2dG55ERO3WbHB32Su3hPf/We/xCwD2BY6b9h6r9zhFlPJGL9ebXgkAXz86izMLObz5tn11j4liYsC92KlJYheX8zg9nwUAWF50p2sCY+m4vweIiIioW9iOxEKmfuZuIJi5G2Tmjog6V7PB3ecBqImXbwPwucDjb/WmZr4EwIpXvvklAK8RQox5g1Re4z1GEaW8C0ymWD+4+/v/OIndI0n84E27N+U11ZoDNTHzff9+BO/658cBAI5XHqppAiOpGFchEBFR11nKleDI2jvuAHclEKDKMhNYyZsobVBBQ0TULmFWIXwSwHcAXCuEOC+EeAeAPwbwA0KI5wF8v/c5ANwN4CSA4wD+HsAvAYCUchHA+wE87P33Pu8xiigVd//K1gq1g6jVgokHTi7iTS/eh5jectUtgPLFTpWhzGeKfm+dHSjLHEvHWZZJRERdRy0wr5e52zEQh64J7BtL+zc8OUCMiDpRwyXmUsq31PnSq2scKwH8cp1f56MAPhrp7GgdVZaZqVOWqS5Q+8cHNu01/cydV4aSKVrIef13aqCKrsHruWPmjoiIuotqO6iXudsxEMfdv/pyXD05gK88e9l/ztRwctvOkYgojM1J7VBTZlbyuOH3vojnLq2Gfo7fc1enLLPR3cdmjHs9d3Pexc8N7tzXV2WZuqZhNB3HasH0Az4iIqJuEObaee2uIRi6FqhmYeaOiDoPg7s2OreYR7Zk4+xCLvRzkl5wN7dWxDeOzq77eqO7j81IxXUMxPWKzF3eXJ+5G0vHICWwyr47IiLqIuVrZ+09d0HjKrjjrjsi6kAM7tqo4AVIph0+05WOu8Hdf/23p/H2jz3sT61UtiJzBwBTI0mcX8pBSols0YJpS5i2A8sL7jQh/Nd84OTCpr42ERHRVppdLSJhaP6y8o1UtyoQEXUSBndtpII7tU4gDJW5U+yqZebzmSJ0TWA0FWv9BANu2DOCpy+soGg5fjCaK9mBskyB73/BFG7YM4z3/MtTWMryokdERN3hyMwqDk0NQQjR8NihhIG4rvmtCkREnYTBXRsVvDHKUTJ3WtWFp7q/bW6tiInBODSt8QUqipv3juDiSgFnAiWk+ZJdLssUAsmYjt98zSGs5E2cnM9s6usTERFtBduRePL8Cm7ZNxrqeCEExgZivIlJRB2JwV0b+Zk7O3zmzqw6tnrPznymtKn9dsrN0yMAgO+cmPcfy5UsOE45cwcAgwk3Y1gwuf+HiIg634m5DDJFK3RwB8Bb/cP+ciLqPAzu2qioeu4iTJesztQVq4K7ubXipvfbAcANe0cgBPDtE+V+urxp+2WhKrhLxtxvKRW4EhERdbLHzy4DAG65InxwN5Li6h8i6kwM7tpIZbdMK3yWy6oK7tZn7opbkrkbTBg4MDGAh06Xd8/nS3Z5oIof3Lk9gXkGd0RE1AWeOL+MoaSBAxH2w46l41xiTkQdicFdGzUzUKU6cxcs05RSYj6zNZk7ANg3lq64U5kr2eWyTK8XMGm4wR3LMomIqBucW8rjqomBSL3qo+kYlrn2h4g6EIO7NipY0VchVAeCwczdSt6EacstydwBwO6RZMXnueBAFZW5i7Msk4iIusfMch67qq5vjYym41jOlSBl+Os3EdF2YHDXRiq7ZUUI7qozd6VA5u78Uh4AsHc02kUqrN0jqYrP86blr0JQUzxVWSaDOyIi6gYzK4V117dGxtIxmLZErsRrHRF1FgZ3bVReYh5lWmb9nrtzi+6agumx9Cac3Xq1M3fux4ZeXZbJCx4REXW21YKJTNHCnog3RUfT7mRo9t0RUadhcNdG/kCVFnrugsHdWS+4u2J8a4K76rIVd6CK+/oqcxfTBTTBnjsiIup8M8sFAMCuiJm70XQcADgxk4g6DoO7NlI9d1HKMqunZRbtyuBuNB3DcDK2OSdYRWXuUl7pZa5k+2WZqudOCIFUTGfmjoiIOt7MitvOsCdiz90Ygzsi6lAM7tqoUIq+xNx2HLzy2kl8/OduA7A+c3fFjq3J2gHlzN1YOoaYLtw9d97Lq2mZgNt3pwJXIiKiTjWz4mbudo9GzdyxLJOIOhODuzZSAVApYuZuKBnD4f1j7nOreu72bWFwN5SMYTBhYCBhIBXTkQ+sQtAC30nJmI58iWWZRETU2WaW89AEsDPiCiEV3IVdh7BWMPEr/+sxLGYZDBLR1mJw10blaZkRlpjbEoYmENfdvzo1jMV2JC4s57c0cwe42bvBpIF03ECuZMH2yjKNQHSXiGnM3BERUce7uFLA5FACMT3a26HRlFeWGTJYO3JxFV94cgZPnF+OfI5ERFEwuGuj8hLzaKsQdE3A0DVoopy5u7RagGlL7NuiSZnK62/ajVdftxPpuI5cyfbPvSJzZ+gosueOiIg62HKuhHuPXMZNe0cjPzduaBiI66Ezd+paaVqsaiGirWW0+wT6WTOrECzHgeENL4kbmr/nbnZVTfzamgXmym/8wCEAwN1PXaooywz23KXiOqdlEhFRR/vgN05grWDit+481NTzxwbiocss1XW+ep3RVvni0zPIFG38+K3T2/J6RNQ5mLlrI38VQqSBKtKfTBnXNT9zt5BxLzDjA1sb3Ckqc6dWM6hzAoBkTOO0TCIi6mgPnlrEbQd24Lpdw009f89ICheW86GOVUGdFWH1USv+10Pn8PHvnN6W1yKizsLgro2KTa5CUL0BcUNH0Qvu1N3DHQPxTT7L2lJxHTmzvApBCwZ3ho48gzsiIupgq3kT44PN3xCdHkvhwlK44E711pe2qSzTcaR/fSai/sLgro3KS8wjBHd2MHMnypk7L7gbH9ye4C4d15EvWeXMXfUqBAZ3RETUwZbzJkZTze+FnR5LYWYlH6r6Rl3nt6ss03YktilJSEQdhsFdG/kDVTah524xW0QqpiMd3542yonBBC4uF/wMXWVZJnvuiIioc0kpsZI3MdJScJeGI4FL3q68jVh29DaMVjiSmTuifsXgrk0s2/GnZ0Upy6zouTM0f/LWQqa0bSWZAPAD108hU7TwtedmAazvuStyFQIREXWorNczrvbVNWN6zF18fm4p1/BYsw3BHWM7ov7E4K5NCoG6+1KkzJ2smblbyJa2rSQTAF52zQR2DMTx5PkVAOvLMvMlBndERNSZlnNuK0OrmTsAOB+i706VY0a53rfCZs8dUd9icNcmwZ60sNOzHMe9E6d7S+WC0zIXsyWMb2PmLqZr+KGbd/ufa9XTMrnLh4iIOtSKt59uJNX8dXPXSBKaCBfc+WWZ1vYEXI4EgzuiPsXgrk0qgruQZZmmFwQaeiBz55dlFrFjm9YgKL/66oM1H08aOmxH1i0/WcyWsFYIt/iViIhos63kVHDXfOYubmjYNZzE+cUwZZlqoEr4G593ffs0bv/vX2nq3FiWSdS/uMS8TYIDR8L+sFeTKctlmTpW8iaklFjIljCxjWWZgDtU5aNvP4yvPzdX8XgqrgNwA1i1tiHoRe+/F0NJA0/9/p3bcp5ERERBKnPXSs8dABzaNYQnzi83PE7dnDUjjLB87+efAeBm/Ywa19KN2I6EzeiOqC8xc9cmKnM3mDBCj0a2qhaGq1UIuZKNouVs60AV5VXXTeH9b7yx4rFETAV39S9iawVrS8+LiIionnJZZmvB3cuunsCJuWzDiZmqQqeZssxsEz3s7Lkj6l8M7tokGNyFXYVg29WZOw0ly972BeaNJA3324q77oiIqBMtb1Lm7mXXTAAA7j8+v+FxzaxCiHvX0kwx+s1QKcE9d0R9isFdmxS9XrnBpBF6ibmfudPLA1VMW2J2zb1jODG4vT139SRj5bLMjUjeVSQiojZYyZuI6QIp73rVrOt2DWF8IN4wuCs10XOnbpRmmwjubCl5jSXqUwzu2kSNQx6I6+Ezd15wF9MqB6o8d2kNAHBwanALzjS6VIiyTKBcFkNERLSdlnMmRlJxiMAan2ZomsAL94361+F61HU+yioEdaO0mTYGx5EIed+YiHoMg7s2UfX3yZgeuudO3fHTq/bcPXNxFcNJA3tHU1tzshH5mbsGi8xn14rbcTpEREQVVvMmRlKbM1Nu31gK5xssMleVN2Gv90D5Wtps5o49d0T9icFdm6i7eKm4Hn1aplqFoOsoWQ6OXFzF9XuGW74DuVkGEu4FabVGZi5YJjK7yuCOiIi230rebHmYijI9lsZqwdqwGqXk77mLkrlrvufOkczcEfUrBndtovrsUjHdv6PXSHlaptdzZ2goWjaeu7SK63ePbM2JNmHfjjQA4GyN3T/B36vqFSQiItpOS7kSRtObM4RsesytmrmwwTLzZgaqqMxdpqmyTPa1E/UrBndtEszc2Y6EEyLAW7fnThcwbYmC6eD6PcNbd7IRjQ/EMZgwcGZhfXBXCty1ZFkmERG1w+XVAqaGk5vya02PuTc0NyrN9FchREinJVqYlsk9d0T9i8Fdm6gf9Gr4SJjFppazvudOuX535wR3QghcOZ7G6YXsuq9VBHcsyyQiom1WtGzMZ0rYPbJZwZ2buTu/QeZOBXVRyjIThpe5a7Ysk3WZRH2JwV2bqGBOBXdWiCZrdUxMrwzuYrrANTs7Y1Kmsn98oGbmLliSwrJMIiLaburG4q5NCu5G0zEMxPWNgzsrelmmaqNvZqCKIyWYuCPqTy0Fd0KI3xBCPCOEeFoI8UkhRFIIcUAI8aAQ4rgQ4tNCiLh3bML7/Lj39f2b8RvoVuoHfSoeIbir7rnz9t0d3DlUkcXrBFeOp3FuMbduzUMxcNdyIVPa7tMiIqI+N7Pi3ljcrMydEALTY+mNyzKd6MGdOnatybJMTssk6k9NRwRCiL0AfhXAYSnljQB0AG8G8CcAPiClvAbAEoB3eE95B4Al7/EPeMf1LRWoqeCuVlnmd04s4Ilzy/7n63ruvJKNTuq3U/aPD8ByJC4uV2bngjt+ig1WJRAREW22mRU3w7ZZwR0A7NuRqtmKoKgVCKUIqxDUTd+mViFwzx1R32o13WMASAkhDABpADMAXgXgs97X7wLwRu/jN3ifw/v6q0WnzO5vA7O6567G3bz3f+EI/vzeY/7n9XruOqnfTrly3G0wr77YBXvuihF6D4iIiDbDJS9zt2tk83bDXr97GMdnM8iXat+0NJuYlqluAjczLVNKMHNH1KeaDu6klBcA/BmAs3CDuhUAjwJYllKqn0TnAez1Pt4L4Jz3XMs7frz61xVCvFMI8YgQ4pG5ublmT6/j+dMyN+i5WyuaWM6VSxerM3dqktYLOjC42+s1mKs7pIoK7pIxjcEdERFtu5mVAoYSBgYTm7PEHABumh6FI4FnLq7U/Lo/LTNScOce29S0TPbcEfWtVsoyx+Bm4w4A2ANgAMBrWz0hKeWHpJSHpZSHJycnW/3lOpaanJXcIHOXK9pYDixFVRcHlbl7xaFJvPvOa/Hi/WNbfbqRTQ4lAACXqyZiqrLMoWQMBZNlmUREtL1mVvKbNkxFuXna3TX75PnawZ1qvYgyLVNd85tdhcDMHVF/aqUs8/sBnJJSzkkpTQD/AuBlAEa9Mk0AmAZwwfv4AoB9AOB9fQTAQguv39Us20FMF4h5Q1FqLTLPFC2sBIM7R03LdJ8zkorhl7/vGhh6Zw1TAdwRzmPp2LqJmCpzN5Q0mLkjIqJtd2mlsOnB3dRwElPDCTx1oUHmLkIjnLrmNzstk8EdUX9qJSo4C+AlQoi01zv3agBHAHwdwI97x7wNwOe8jz/vfQ7v61+Tsn9/8liOhKFpMLy1BtWZO8t2ULQcrORNf1eNXdVz1+mmhpPrM3deQDecjKFQKo2fAAAgAElEQVTIzB0REW2zS6sF7NqkBeZBN+0dxaNnllDrrU1TPXd282WZjnT/6+O3WUR9q5WeuwfhDkZ5DMBT3q/1IQD/BcC7hBDH4fbUfcR7ykcAjHuPvwvAe1o4765n2g4MXfg768yqnrus15QtZXkMslXVc9fpJocSmF2rDO6KgcxdgZk7IiLaRrYjMZ8pYedwYtN/7VddtxNnF3N45uLquq/5wV2E6556X7DWxEAV1aPP2I6o/7RUzyelfK+U8jop5Y1Syp+RUhallCellLdJKa+RUv4nKWXRO7bgfX6N9/WTm/Nb6E6WLRHTtXJZZtXdvGAZxkrOLc20ncqeu043NZzE7GrtVQjDqRhKlsO7ikREtG0WsyXYjsTOoc3P3L3uxl0wNIF/f+Liuq+pm7PVN3I3ogaqFC0nUsbPCZR+sjSTqP90XrNWn7AcB4YmYHgLyat/4OdKgeDO67tTx6jndLqdQwnMrRUrLjTlsky3LZN9d0REtF1UH/jUFmTuxgbiePnBCdzz9KV1X7P8PXfhb2raNa6dYQQDOu66I+o/3REl9CDTz9y5WTiraol5pljuR1vOu+sQ/J47vXsyd5YjsRhY51AeqBIDABRNBndERLQ9VKvA5BZk7gDg5ulRnFvK+Zm2lbyJD37jBIpW+Zpea4BaLcGbvlEyd7Zk5o6onzG4axPVc6cmXVb/4K4oy/Qyd/60zC4py9zprUM4dmnNv1NZ8i5wQwmVueNQFSIi2h5z3pAvdX3abLtHkpCyHETee+Qy/uSLz2E+U77JGTZQs2wHyZj7HqEUqSyz/DFjO6L+w+BuE3zpmUtYyBQbHxhg2RKGtsFAlUBwt9ylPXc7vWlkP/nhB/F333RbLMt77liWSURE2+uy1wc+uUXBnVqxcGklDwBYypaDOuFduk0rXMRlORLpuHutjNKrx8wdUX9jcNeikuXgP//jo7jzL74Z6Xmm7VQNVKmellkjc9dlPXf7xlL+xx/+j1MomPa6skwuMiciou0yu1bESCqGZEzfkl9/94h73bu47AaRwbaElPeaphMyc+fI8nOa7rljcEfUb7ojSuhgqrxiPlOqGBzSiOVIGLpAwnD/CqqDnGDPnQru/Mxdl/Tc7RxO4mu/eQfu+rnbMJ8p4gtPzvjB3SAzd0REtM1m1wpbVpIJBDN3bnC3HAju0nEvUAtRYimlhO1IpLznRCvLDAR3vMQS9R2j3SfQ7YIZt8fOLuHw/h2hnmfaDgxNw9hAHACwFLgAAEDOK8scShj+KgR1t69b9twBwFWTgzgwMYChpIEnzy8jHTcQ1zX/biR77oiIaLvMrhW3ZMedMpw0kI7r+NbxeeRKNhYDZZkqUAtTlql67FVAGGVaps1VCER9jZm7FgXLK755bC7089w9dwJDCQNxQ8NcVc9etmhBCPcuoD8t0+6unjtFCIF9Y2mcX8qjZDmIG1ogY8nbikREtD1mV4tbsuNOEUJg10gS9x2bwwe+cgzPX874Xxvw+ufCZOHUjWO/LDNK5k4GP2ZwR9RvGNy1KJi5WwsMQWn4PMftuRNCYGIgjvm1ysxdtmRjIG5gLB3HUq5yWmY3Ze6UvWMpnF/KoWTbbnDHzB0REW2j5VwJF1fyuGpiYEtfZ2KgnBk8tZD1P05FKMtUN47LpZzhgzTuuSPqbwzuWhT8IR2lf8y0pb8GYWIogYXs+sxdOq5jekcKp+fdi4PtSOiagBDdF9xNj6XKmTtd88c7c88dERFth4dOLUJK4CVXj2/p65wOBHTBxFmULJy6cVyeltlcWWbYhelE1DsY3LUouIw0SqBiOY6/r258II75qrLMTNHCYMLAoakhzK4VsZIzYXnBXTeaHksjV7JxabXolWW6F7kCM3dERLQNHji5iGRMw83TI1v6Oj9263TNx6MEapaXuVNTPaMMVKnsuQv9NKKe4TgSf3TPs3j6wkq7T6UtGNy1yAr8wA3zwzdbtHD3UzPunjtv6uXEYAILmaqBKiUb6YSOQ1ODAIDnZ9dg2U5XlmQCbuYOAE7OZSp67pi5IyKi7fDAyQXceuWYf3Nxq7z7Ndfi2fe9FoOJypl15eEoIQaq2JUDVaKsQpDsuaM+d3mtgL+77yR+6K++1ZcBHoO7FgXr4Ishdrb9f0/O4Jc+8RjOLOT8ssxxL7gLlk9kihYG4gYO7hwCADxxfgUPnFrwl393GxXcnV/Ke2WZqueOwR0REW0t25F47tIqXjg9uuWvpWkCqbiOPaOVg1uirEJYF9xxiTlRaMF5GPdFGHbYKxjctShqz51aeZA3bb8sc2IwjpLtYLVQHsiS9coy946mkIrpeP8XjuDIxVW87w03bvLvYHtMj6X9jyunZbIsk4iIttZq3oQjgckt3HFXbc9oquJzNVDFCrF8Th0TZQiLYnPPHfW5YMtUNsKww17B4K5FwR/SYSY/ZgLfZP5AlUH3YqP67rJFCzMrBQynYtA0gbwXAL3nddfhzht2bdq5b6eRVAwjqRiAyuCOmTsiItpq6sbqWDq+ba9ZHdz5qxAi7LlTQ1ii7LlzmLmjPhdsmcqV+i+JwOCuRWZg91yYQGUtkJ2LBXruAPh9d3/25aNYypXwU7dfAQD4gx+5AT91+xX4+Zdftannvt1u3DsMAEgYGgxdg6EJrkIgIqItp1YKjaZj2/aae73gbqeXLVRtFblS40yCytSlE+F34ykM7qjfBTN3mT7M3HVnA1cHUXW9A3E91J211YLpf2xoqufOvZM4nynizEIWH//OGfzkbVfg8P4dAIC3vXT/Jp91e9w8PYr7jy/4nycMjUvMiYhoyy1l3ZunOwa2L3P3muuncGI2g0urBcyuFTHu3chdzpkNnlkurUw3scSc0zKp3wV77sLcTOk1zNy1SC0aHUwYkTN3alrmrmG36frEbAZ//bXjMDSBX3v1wS042/a6ea87fvrEbAaAO+KZmTsiItpq7SjLPDg1hD9/0y3+1MxkTIMQwHK+cXCnqoKa6bkL9tlxzx31o2DLVLbYf+8zmblrkZ+5SxihdratBTJ3Ma/nbmwgjluvHMOnHj6HS6sFvO1792PncLLeL9G1bt7nTim7uFIA4GbuuAqBiIi2mgrutrMsU0nFy31zw8kYVnKlBs8o9wylmpiWWVmWGeVMiXpDsCyTmTuKzArUxYcJVCoGqgR21v3wzbtxYTkPQxP4hTu6u7eunj0jbsB63S53vUMipqPAgSpERLTFlnImYrpYt3tuO6ihKAXTwWg65vf/baSVgSpchUD9TiVehhIGMhEyd7Yj4fTAHREGdy0yvW+CwYQequG5siyz/Mf/+pv3IK5r+OmXXNmTWTsAEELgP377+/Cpd74EgMrc9V+6nIiIttdyroTRdBxCiMYHb7Ifv3UaAPCSq3ZgNBULVZapgruYLhDTRcSyTAZ31N9U3+lwKhYpc3f3UzO46v+8G89fXtuqU9sWLMtskcrcDcTDZe6CwV1cL19kJocSuPddr1g3OrnX7NtR3neXiOlchUBERFtuMVvCWBtKMgHg8P4dOP3HrwcAjKbjWI5QlmloGmK6xj13RBGoeRjDqRjm1oqhn5f31iaocuhuxcxdi1Tq1x2oYm/YvCylrOi5C2buAODK8QG/D68fuNMymbkjIqKttZQzt3WYSj2j6XCZO9VjZ+jCC+6i9NwFP2bmjvqP7f17GUkZkTJ36th0vLtzX/0TSWwRdXdgIGHAkZVNnNWKllPxAzrYc9ePkjGdwR0REW255VypM4K7VMxfy7AR2y/LdDN3UapcuOeO+p2aljmcjCFXskP30WW9zF2ambv+pjJ36YT7jbDRD+BgSSaAvsrS1TI9lsKp+SxHNRMR0ZZazJoYG2hPWWbQSDqO1YLlB29/dM+zuO/Y3Lrj1JtTXRNIGC2UZfLySn1IJVpGUu6/+VzIREK+ZEMTbmVZN+vus+8A6gfuoJfC3WiiVbAkEyjvuetX1+8exmrBwoXlfN1jLi7n8daPPoQzC9ltPDMiIuoVUsqOydypvr/VvIm1gom/u+8k/uWx8+uOU1U+MU2LPlAlcMOUN09ps3zr+Xn80icejTS5tV0suyq4K4YrzcyVbKTjRlsGL20mBnctUncHBrzxyhst5V6XudP6+4//+j3DAIAjF1drfl1KiZ/+yIP45rE53H98YTtPjYiIesRa0YLlyI4I7tSeveW8iecuuRP5zizk1h1ne5m7cs9ds2WZrZwtUdlffu153P3UJXz8O6fbfSoNWYFpmUC53LKRXMnq+mEqAIO7lqmJVmp3Tr2JmU+eX8bv/ttTAMrp3n7P3F23awhCAEdmagd3z1xcxck5N2OXZ28eERE1YTnrVs20Y4F5tdGUG2Au5Ur+jc2zi+uDO3+giuYGdyUrfJQWjAPZc0ebRb1j/cuvPt/x2Tt1c0Rl7rIRMncDDO7IDNlz93ufewZPX3B/kE95e+yqp2X2m3TcwIGJgbqZu8VA03mY0dFERETVlrzrRydk7ka8AHMlZ/rXvsVsCWsFE5dXC5hdKwAIrELQNcRa6rljcEeb44R3s321YIUOltrFrCrLjBLcpbp8UibA4K5lluNA1wSShhvc1bubEbxjODWcAADE+nxaJuBm747PZmp+LfhnuRhiuhgREVG1RRXcDbQ/uFMB5txaEUdmVqF77wPOLubw1o88hHd9+gkA5bIyQxeIR+y5C/bZcc8dVZNS4sGTC5H6MVfyJuYzRez1djFvNBm+E5SXmLuBWi5kWWbetLp+UibA4K5lli1haAKJmPtHWa/nbiFTDk52jbj/OPo9cwcAk4MJLNQJ3EqBi9lyrvFeICIiomrLfuau/WWZ02MpTI+l8D+/cRzPXVrFS68eBwD8+xMzOHp5zW9T8IM7LXrPnc1VCLSBh08v4U0fegCPnFkK/ZyTc+5N+Gt3DQGozA53IvXvxc/chdx1ly3aDO7ITf3GdA0JY31Z5pefuYSP3X8KgDv18Ue/Zy8+8wvfi51Dbuau33vuAGA0HcdK3vRLUIJU5m5iMM7MHRERNWXJ67nrhLLMmK7hPa+7DqcXctg5lMR7f/gGAMDf3ncCgFulspgtlcsyNc3ruWNZJm2OmRV3Qvn5pfW9nvWoksyDU4MAyqs6tsM/3H8K3zg6G+k5ttNcWWa+1BvBXfcXlraZ5Thu2YSxPnP3zn98FABw5w27sJAt4eqdg3jx/h34prfTpt+nZQLADq9MZiVvYnwwUfE1dTGbGk76PRNERERRLOVK0ER5cl67vf6m3Vj7UQsvu3oCV4ynoQl3quWhqUEcu5zB8dlMeRWC9/6iZIcP0ipXIWz66VOXm/cqyebWiqGfc2o+A10TuGpiAMD2Ze6klPizLx/Dyw9O4JXX7gz9vHXTMoshp2WaFtI90HPX/b+DNjNtCUPT/AmYtaZlqjtye0bdQSrqG4eZu3Iv4lKutC64U4Hy1HASz1xc2fZzIyKi7reUK2EkFfP729pNCIG33HaF//k/veN2mI7EVRMDePn/+DqOz2ZgOxK6JiCEQDzqKgROy6QNLGbdoG52NXxwp8oVkzE3q7VdPXeXVgvIFK3IrTlqz91w0ttzF7Isk5k7AuBOtIrpwg/ugn1iI6kYVvImPv6dMwCAPV6vnfrGibHnzs/cLdX4h1sMZO6+9fw8pJRdv1iSiIi211LO7IiSzHpees0EAMBxJFIxHc/PriFuaH4wGnWJuc09d7QBNQNiLhM+uLMdd76E+p7crsydGri3nI8W3NmOAyGAZExHTBeh99z1Ss8dg7sWWY6EoQskvLsZKnNXMG2s5E1cOZ72F5Tu8aYMpfzgjoGKuuDW6qlTgfLUcAIl23H3jyT4LUtEROEtZUsdMSmzEU0TODAxgI/dfxoAkPQGtcV0DWaEnjuHPXe0AVWWGSVz577X1WB4wZ0VoUy4FSq4W4nYmmN6wSgApGI68iGCO8eRyJtchUBwJ/LENA1xvbLn7vKqu6vmF+642j9214hbljmcdL9xVHq7n6kLbq09dsGeO4DrEIiIKDo3c9cZ/XaN/Mz3XonbD+wAABS8m8WxyD135Y+jjLun/rDglWVGy9w5XuZO8z4P/331mUfO4RMPnol2kp7mM3fSzzKm4joKZu3g7vjsGr70zCUAQMF7/94LS8y7PzxtM8tWmTv3G/7bJxbwt/edxIC31HzvaAr/+I7b8NCpRb8M8/uu24k//4kX4uDOwbadd6dQF9zF7Pp/uCXL/WEy4fXiLedM7NuxradHRERdbilbwg17htt9GqG85bYr8OYX78NL/uir/pTPqD13LMukjagb5bNeEiIMywuWVDbMjnDT4N2ffRIA8FO3XxnhLF0quMuVbBQt259M34hKvADunIt6e+7++J6j+NbxOTz7vtf6Q1f6vixTCDEK4MMAbgQgAfwcgKMAPg1gP4DTAH5CSrkk3Gap/wfADwLIAXi7lPKxVl6/E1iOUzFQ5Z6nL1V8fddIEoemhvDyg5P+YwlDx4++aHpbz7NTpWI6EoZWN3MXN7RyAMiJmUREFNFSruT3d3cDIQS+9V9ehUzBHQIRtecuWJbZ6fvIaPupnrvVgoWCaYeqIlvfc7c9qxBOzWf9abIreRM7h8IFXrYjoXutT8mYjnyNzF3JcvDtE/MomA5m14p+WxXLMt1g7YtSyusAvBDAswDeA+CrUsqDAL7qfQ4ArwNw0PvvnQA+2OJrdwR3z53wyzIB4IX7Rv2Pp4aS7TitriGEwFi69h67ku0Gd6NeX94SyzKJiCiCfMlG0XL8yczdIqZrfttC3IiYuWPPHdVRMG1kihau2JEGEH4dgmVXZu62q+cub9r+JPWVCBMzLcedZA8AqZhWsyzzkTOLfkbvzEIOOdO9mdILmbumgzshxAiAVwD4CABIKUtSymUAbwBwl3fYXQDe6H38BgAfl64HAIwKIXY3feYdwt1zp1VMcfzVV10DAEgYGoZT3X8HYKuNDcRrT8s0HcR1zS9xrVczTUREVMuJObesS02r7kYxXYNpy4qM3Ea4547qUTfSr9s1BACYDRvceVVq2z0t03YkxtVshgh9d5bt+IFovbLMbx6b9z8+s5D1j+nr4A7AAQBzAD4mhPiuEOLDQogBAFNSyhnvmEsApryP9wI4F3j+ee+xCkKIdwohHhFCPDI3N9fC6W0Pd89d5dTLV167E0MJA1PDSY7uD2EsHau5pFxl7lSvYinCnUsiIqJvPu++j3jp1eNtPpPmqWugGbIUzpHM3FFtqiTzWi+4CzuoTg0oUcFdM3vuwt6cCLJsicmh8tyF0M8LDFRJ1pmWeWIug6smB6AJ4OxiDjm/5677kzKtBHcGgBcB+KCU8nsAZFEuwQQASHdMU6S/TSnlh6SUh6WUhycnJxs/oc3cPXflP8aXXTMOXRN4xaFJ/x8PbczN3NXvufODuwijoImIiO47Oofrdw9j53D3tkiotg8zZCmcXbHEfCvOiLrVvDcpU01vD/u+Sq39aiVzlw25SDzIdJzAUL3wrTmW1zIFuJm4Wj13C5kido8ksWc0hacvrOArz172j+92rYSn5wGcl1I+6H3+WbjB3WUhxG4p5YxXdjnrff0CgH2B5097j3U19Q0PAEf/22uhe5m6D7zplnaeVleZHEzgGysFOI6EFsiCFi0HCUOvuSCeiIhoI5mihUfPLOHnX3FVu0+lJepNaslygETj45m5o3qyRTfA2uHNMrBCZoPVQBXVx9ZM5i5TtDCUDN/76jgSUsIvy1yJUJZZsQqhTuZuIVvCC8fcGRlfPzoHtxixN4K7pjN3UspLAM4JIa71Hno1gCMAPg/gbd5jbwPwOe/jzwN4q3C9BMBKoHyza5WscuYuYegwvI/jhoa4wTWCYbxg9xCyJRvnlnIVj1eXZZoWL1JERBTOqbksLEfilsCQs26kdr2eXsiGOj5Y/sY9dxSkdieqICtsNtiyZVXPXfSb7SqwDEuVIY8NxKFrIlJwZwaq6lJ1M3clTAwm1vWlDia6vyyz1d/B/wHgE0KIOICTAH4WbsD4z0KIdwA4A+AnvGPvhrsG4TjcVQg/2+JrdwTLKad+qTnX7x4BABy5uIorxwf8x0uWjYSu+XXeUaaFERFRf5vLuHu8dg6FSHd1sMP73QWvD59axIuuGGt4PPfcUT0qyBlKum//rZDvq1QmTFWqNZe5izYUT5V+GprASCoWqeeueol5deZOTQ0dH4zjXT9wCNfumsEvvvJq/Mex+a4u4VZaCu6klI8DOFzjS6+ucawE8MutvF4ncifyMEPXioNTg9A1gSMzq3jdTeUBqiXL8RtbY7pgWSYREYWmxrxPdnlwNzmUwIGJATx8egn/+Y7Gx3PPHdVT9IK7QS+4M0N+f1iOg0TMaKnnTu1tDEtlFQ1dw2gqFm1aplMedpiK6SjZjvt+3cvmzWfcnw0Tg3Ec3r/Dv4HyY7f2xg5qRiUtMu1yzx01JxnTcc3kII5cXK14vOgNVAHchnIOVCEiorBUcKcGMnSzF+8fwyNnFkNNHAwewrJMClIrpYYS0TJ3avpkK3vuMhHLMtW5xXSBwaSBTCFKcFcO5FLekvZC4D2kmho6PtD9PxtqYXDXIstxEGPmrmXX7xnGM1XBXcly/ClhcUNj5o6IiEKbWytiOGkgGev+AQm3XjmG5ZyJs4u5hseyLJPqKZgONOGWKgLhgzTLW/vlZ+6auGkQNbhT2UFdE+4N/gjvAdXSdaD8e80FpnUueFNDxwfjkc6pWzAqaZHFzN2muGnvCC6tFjCzkvcfK9kOEjH3WzSmazCZuSMiopDmMsWuL8lU9o6mAQCXVgsNjw1m9zgtk4IKpo1kTI+8O9HvufOSGU2tQog8UMV9jZimIRHTUDQjBHeBeRh+5q5Ufv68l7nrhax+LQzuWmRW7bmj5tx2wGsYP73kP8bMHRERNWturXeCu53D7u9DlZpuxHaYuaPa8l5wp8orw04hV2WOrSwxj5y5s1vI3DkSuheIqtUGD59exMVlN4Hgl2Uyc0e1BJs2qXnX7RrCQFzHw6cW/cdKgZ67mK5xWiYREYXmBnfdP/kOcPfBAsBsiOCOPXdUT8F0kDTcIE2IZvbceWWZEd6PeeufIwd3Kqto6MK9wR+hesuyHcS8c016wd1vfuYJ/MkXnwPgDlRJx3V/aF+vYXDXIrcsk3+MrTJ0DS+6cgwPn64d3LkDVXiRIiKicObWin5Q1O1G0zHEdBEqc+fI8k1nlmX2ts8+eh4XlvOND/QULBvJuA4hBGKaFn7PnVeWqUdchaAWkQPRyzJVP6ChaUgYOooRgrvqJebK6Xl3V+RCptizWTuAwV1kx2fX8Ouf+i6Wsm5K13Qc7rnbJLft34Gjl9ew4u0yCU7LjLEsk4iIQsoWLWRLds+UZQohMDmYwOxa45472ynPAmBZZu/6+tFZ/NZnnsD//eWjoZ9TNG0kDTfYMXQRac9dReYu5DdWsKcv8rTMVjJ3gX8DqiwTAM4u5nBiLoN7j1zGdbuGI51PN2FwF5FpS/zb4xfxr9+9ANu7I8E9d5vj8P4dkBJ49OwipJTuQBUvK5rgQBUiIgpJ7bHqleAOACaHk6Ezd7EWBl9Q53MciT+6+1kAwFg6fAaqYDpIeoPqDE2EzsCpHraoPXfB77+oe+5U5i7mBXdRMnfBHdTBzN1SzsRvf/ZJxA0N73vDDZHOp5swKonoBbuH8cLpEXz64XN+DxinZW6OW/aNIqYLPHRqyc/SJbx/lDGDS8yJiCicXllgHjQ5mAhflum9L2HPXW9ayJZw7HIGABDlr1gNVAGizTJwgyUBXUTM3AXKPrOlqJk7NVBFQ8LQULTsSM9VWcbqVSiPnlnCG27Zi90jqUjn000Y3DXhTS++Akcvr+ERb7IjyzI3Ryqu48a9I3jk9KKffvenZXKgChERheQHdz3Scwe4EzPDTstUswCYuOtN+VI50IkS9BQCwZ1blhmx525bM3feEnOtmYEqtcsylRddORbpXLoNg7sm/Mgte5CO6/jHB04DYFnmZrpt/w48eX7Fr80OTsuM8g+biIj611wvlmUOJrCQLTW80Wk78CcFcqBKb8qZ5UApSrliwbT9MkVDC3/TXPXcCeEGeHbIKZvBaZy5Uvgg1H1ueRVCwluFEDYTHVyFkKoV3F0xGulcug2jkiYMJgz80M278aVnLgMArtk52OYz6h037B1ByXZw9NIaAIQeqHL/8Xl84sEz23KORETU2ebWitAEsGOgdybiqUBV7eiqR0rpTzVk5q435Soyd1GCOweJWHl/sBmh505lg93gLtzrBTODUVtrVHBn6BoSMR1SIsJ0T6dclmmUg7uRVAxTwwnsHe3dkkyAwV3T3nzbFQCAt9x2BV5xaLLNZ9M7DowPAEA5uAsOVNngB8Ovf/px/O6/Po0HTi5s/UkSEVFHm1srYnww4ZeR9YKpYXdn38WVjUff21JCEwKaYM9drwqWZZYilGUWrUBZphZ9WqZ6XtjMnSrL1AQiV1+pczO8JeZA+ADRDpRlaoGfAS+6YhSvum4KQvTOz4VaenN73zZ40RVj+PJvvAJXTQy0+1R6yv6JNADg6OWqzF2DssxDU4OYWyvi9z//DL7466/Y+hMlIqKO1Us77pTrdg0BAI5cXMWLrqjfM2Q7EroQ0IRgWWaPUpk7IaJl7vKl4CqEcHvupJQVe+P0CFM21U35gbgRPbjzM3fCfy9YshwgxD/r4EAVABhKGvhPt+7D//VDL4h0Dt2KwV0LDk0NtfsUes5QMoaJwTiOecFdwgiUD2zwQ0j1PT53ac1bTtlbF3UiIgpvLlPsqX47AJgeS2EkFcPTF1Y2PM6REpqmgrttOjnaVjlv8uRYOo6iGaEs03KQiqub5qKiJ64elX2rzNxFG6iSiusV2cYwyqsQNP+9YNjhMZbj+GWkAPDU798Z6bW7HcsyqePsHx/AsUvuiN+wmbtgyeYT55e39gSJiEJQhgYAACAASURBVKijza31XnAnhMBNe0fwVKPgzgF0ISCEuw+Neo8KlEbTsdABj2k7sB1Zztxp4aZl+oNNdJW50yJk7tzjBhIGipF77hzv9aoyd6GeW5m56zcM7qjj7J8Y8Ouq44HM3Ua11pYt8cLpEWgCePwsgzsion7lOBLzPZi5A4Cbpkdw9NIaCmb9N/S2lBACLMvsYaoscywdD92Hpr5nyqsQwk3LtGpl7kIONvEzdzEdJSv8tEsgkLnTtEjBne1ISIme6reNisEddZwDgT5GvyxTFzA3GINbsh0Mp2I4NDWEx89vfFeTiIh610rehGnLnuu5A4Cb9o7AcqQ/dKwWJ7CTjIm7zvftE/N45mK09y15UwV3sdBlmXk/uAuWZTb+BlGBnFotEKnnzsu+qV1zUSZm+pk7XSDhZRvD9Beq58X0/g1x+vd3Th3rtgM7/I8nvItzTNcgZf3FmabtIK5ruGXfKJ5iWSYRUd/qxR13yk17RwBgw9JMR7rBnRDcc9cNfvLvH8Tr//JbkZ6TK1nQNeGWO4YsVVRBYMLL3MVCZ+7KUysBd8BJ1GmZ6YQ74iPSInJHZe7KZZlhfq/qNfs5c8eBKtRxXrx/B557/2sxnyliesydnqn+YZu2U/NujGVLxHQNk0MJrORNSCl7ftQtERGtd2HZXRWwsweDuzBDVWzp9udpQiBKbLdWMJGOG339prhbZIs20jEdSUMPHTCpsszKJeYhMneBqZVAc9My095rRgru7HKQ5q9CCPF89Xtizx1Rh0nGdD+wA8rp9Xr/sE3bgaELJGM6HBl9WSYREfWG75xYQFzXcNP0SLtPZdOFGariOBK6cHeLhc3c2Y7EHX/6DXzyobObdaq0hfIlG6m4jkRMCz1QpeBl7pJ+5i7cnruaPXcRp2WmE82UZQaXmNeflnl6Pot3f+YJfPvEfMVrMrgj6nB+M22dHwym45ZlqjtShRKDOyKifnTf0Tm8+MAY0vHeLE66aXoExy6v1X1Tr3aSRRmoUjBtLGZLOLeY28xTpS2SM22k4zriuha6LLNgVfbcGXq4qZflMkfN/3/YzJ3Kvg3EmyjLtFXv3MaZu089fA6fefQ8fvLvH8Tp+Wx5+Tl77og6m/qHXa+EwLQkDF0g5TXt5jeYJEZERL1pZiWPo5fXcMehyXafypa5ae8ITLv+UBXHa0sQEfbcqZK9taK1WadJWyhfspCKG17mLuRAlVLltMyYJpqalqlr4VdsWNWZuyZ67nRN+MP1at3gf/DUgv/1Z2dW151vP2JwR12h0Rhc1YunMncM7oiI+s9jZ9yBWi+9eqLNZ7J11FCVJ+tMhnakhC4ENIHQo+dVgJBlcNe02dUCnmxhoFuUNQG5kpu5Sxg6bEeGKq9c13Onh9xzZ5f3zbn/D5+5U4NX0jE3cxc2EHVft7wKwZ+WWTUZNFey8NT5FbzltisAACfmMhW9ev2KwR11hZheHqhSiwru1B2pXIkXKCKifnN5tQDAHTzSqxoNVbEct5JFj9Abpd74Zwq8djbr9X/1LfzIX9/f9PPV7rqwx6bjesOWlaCCpXrugmWZW9tzV15i3twqBCEALbjEvOr5j51ZhuVIfN91O7F7JIkTc1muQgCDO+oSMW9KU/3MnUQsUJa50YJXIiLqTXOZImK6wEgq1u5T2TKNhqpkChYGE4bXcxfu11TDNliW2by5NXcFR5gsWi2ZCH/2+ZKNVEz3yxHD7Loreu+LVBYsrmuhl4IDwcydCBUUBp+r3ptFLcuMeX1+Kri7vFrwb+AAbkmmrgnceuUYrp4cxIm5DM4v5Stesx8xuKOu0OjulOVUlWVyoAoRUd+ZWyticjDR86twbtxbf6jKSt7EcDIWac+d+nVYltm6lbzZ1PPWCuGflzMtvywTCFfuqI5RAaERcqWBv29OLz8vfObOfc1mB6qogFKd81985Xm88+OP+Mc8eHIRN+4ZxmDCwNWTAzg5l8XffP04dg4lerrvthEGd9QVNpqUJKWEaUsY7LkjIuprc2vFnlxeXu3m6fpDVVYLJkbSsUh77lTmLkr2iCqp+wlLufBBWnAwyWqEkth8yUY6YZQHjYQImtQx6ma5oWuheu5U31xl5i7aKoRmMnfu+zpRcc4AcGIuCyklCqaNx88t4/arxgEAV+8cRKZo4cFTi/iFO67223T6EYM76grBJebV1A+ZuC6QirvHMbgjIuo/c2tFTAz2fnCnhqpUl2YWLRsF08Fw0oi0506NyWfPXfMGE252ajlXCv0cM1DeuBbhzz5XcpeYq/dGYXbdlTN35T13ZpieO7uFnjunahVChJJV25EV2UIVPGeKFlbzFr57dhkl28HtB3YAAG69cgyaAH76JVfgZ773ytCv04t6cwkM9ZyNBqqYgZ0mKe8HSCFCYzIREfWGuUwRN/fg8vJqaqjKU+dXgNvLj6/m3QBhJBWL1HNXZM9dy4YSBtYKVqTMXTBzFrYsU0qJvKmmZargronMnaZByvJexHrW99yFy/gBgO29P2uu565climEQEzT/ODw3FIOD55agBDA4f1ucHfDnhGc+O8/2PMl2WEwc0ddYaNVCKZVrgdnWSYRUX+yHYmFTH+UZdYbqqL6vYZTzfXclSwn0htwKhtMujeXl7LhM3eVwV24wLpgOpAS3p471XPX+D1PybZhaMIPmFTJY6Ndd/60TD165s7fc9dMcGdLxAJBZzDrd2E5jwdPLuIFu4YrhicxsHMxuKOuoDJ3pRp3i1RZQVwXDO6IiPrUYrYER6Ivgjug9lCV1UI5uHN77qKtQgA4VOXZmVW86s++Eam8EgCGkm6QsdR0WWa4zJ1a9RQ1c1c0nYreNTWFvFH/nOX33LnP1fXw0zKtqrLMYqRVCBK6XjtYOz2fxWNnl3D7VTtC/3r9hMEddYWNmoaDZZnquDzLMomI+ooaRT/ZBz13QO2hKn7mLhmLtOcuGBycWcyFuoY+O7OKG9/7JVxczkc88872N18/jpPzWdx3bC7S89T7j+bLMsMF1WofXqqi5y5EWaZdHdxp3jk0yNzV6LkLW+5rtVCWadqOvwqh2j1PX0LRcnD7gfHQv14/YXBHXWGjnjv1gyema9A0gWRM4547IqI+MrtawP/40nMA+idzp4aq/LcvPIvzSzkAwKoX3I2kYhCR9tyVr5lv/Jv78daPPtjwOZ999DwyRQufe/xixDPvbGowSpQBJ0D5vUikgSp29IEq/mCUmBZxz53jHw+4N8SBxkNOWtlz10pZZr1ewMGEgcfPLQMAbjvAzF0tDO6oK2y0xFz9YFLHpGK6f2eLiIh63wfvO4FvHHUzLVPDyTafzfbYtyON9/7w9XjywjL++mvHAZTH6Q+n3GmZ4csyK6+tD59eavic6bEUAPiBZVhfffYy3v2ZJyI9Zzup4C7qWghVYhmlLNOqWIUQLuNXCuyrU5Mvw0yhXJe58wKnRsNRynvuAj13IQeqWLaEJuCvJYi+CmF9mDKadstf77xhCjsG4qF/vX7C4I66wkgqhrih1Sz/MP3gzv12TsV09twREfUJKSW++uwsDl85hr9/62Hs25Fu9yltm5992QG88tBOfPPYHKSUfuZuOBlxWmaIgRzVVDbm/FK0ssx33PUIPvPo+Yodb2Hc89QM/uP5aKWSzVCDUaL2HqogaSkbpSwzeuZOBXJxI5i5CzFQxXL8ncFAOXPXKLgrZ+40//9h99xZjoShadC9QS4lO/z3me04fkAZ9PMvvwp3HJrEB950S+hfq98wuKOuYOgarpkcxHM1FrYGyzIBIBlncEdE1C9OzGVwdjGHN37PXvzA9VPtPp1td8e1k7i4UsDx2QxW8yYShoZkTI+2564qc7d7pHH2U2VhLjTZc7ecDx8EAcBffe04PvKtU029VhRq+EfkzJ0dPXNnNrEKwV9poEccqGLZfqYPKGfiGu2686dl+mWZCD8t03b8KZsJQ9swc1f9fWTVKct820v3466fuw3pOLe51cPgjrrGdbuGcOzy+uCu5A9UKZdlcs8dEVF/UOWYr7puZ5vPpD1ecWgSgPvnsJI3MeyNhm+25w5AqEXwKqCIWpapMn6L2WKk55m203Bs/2bwl2VH7LlTAU+kgSqBwCrsIDiVZY0HyjLDBXeVZZmGFjZzp6ZlqrLMaJk79bz4BsHd8dk1vOyPv4aHTi2Wn2vLioEqf/i/3Yg/+JEbQr1uv2s5uBNC6EKI7wohvuB9fkAI8aAQ4rgQ4tNCiLj3eML7/Lj39f2tvjb1l0O7hjCzUvCngSnqB1OcZZlERH3nwnIegwkDe0ZT7T6Vttg7msIVO9J49MwSVgumv/crSs9d0XIwnCxnQsL0RqmsU8F0ImW5hr2VAQuZaKsGTNvx99puJfX7ipq5UwHPSj565i4dDz8roKLnLlZ/knit51UOVAm35860qzN34aew2o70q6riula3N/DsonuD4ORcxn8suMQcAH7q9ivxtpfuD/W6/W4zMne/BuDZwOd/AuADUsprACwBeIf3+DsALHmPf8A7jii0a6eGAGBd9s5fheD9EEixLJOIqG+s5MyKRcb96OZpd6H5St70gzRdExHKMu2K4RQ5s3FgEwwoTs1lQ5/rcMo9v4UIy74BN8hoVEK4GVQfXLNlmaYtI5UtAu5cgajBXdzQ/JvaYXomqzN36rnBLNxT51dwebVQ8bzqaZlGpGmZTkXmrt5Uz0WvT3F2rZzNdQeqcCl5M1oK7oQQ0wBeD+DD3ucCwKsAfNY75C4Ab/Q+foP3Obyvv1pwlTxFcO0uN7ir7rvzp2UagcwdyzKJiPrCUq6EsYH+Du5eOD2KC8t5nJrL+oGuEOEzLAXTQSrQwxTmGhocjhGlz8zP3EUO7pory7y0Umi4yy1IBTvNrkIAwk+FVK/lBnfRB6pomkBMF+H23IXI3L3jrofxF195vuY5Gv5AlfDfV25pZSC4q/P3sOR9LwQDy2DWj6Jp9U/tLwD8NgD1tzUOYFlKqb5DzwPY6328F8A5APC+vuIdX0EI8U7x/7N33mFulOfav2dGXdqq7bve4obL2sYdY0PoHRIChBoOoSTnpFyknpPC+ZJz0kg4JyQcCIQECCGQRkJNgIABYxvcC+5lm7d5m7S76hrNzPfHzDsatdWsK/Y+v+vislfSzLzSYkn3ez/P/XDcJo7jNg0MHP9UJOLUobrIgRKXFR9q800YGWWZNoHm3BEEQUwQhiMiip0TOxJ9Tp06865nJIrZNerf1UAVc8erYRs82n58Be5e0WTKRTKGgZgVJgBQoDmLvhNQlvnfr+zGWT9eiT9v6jJ9DHOlRscZ+GJ0s8x+B2HCqtBhRch0zx0LVFG/89gt5r7zpAeqMLHG1pCQZAwEYzg8khpsovfcCUbnbhw9d9pxNiF3z50vzMSd0bmTswaqEPk5YnHHcdxVAPoVRdl8DNcDRVEeVxRlkaIoi8rLy4/lqYlTHI7jsKixFBvbfSm3i1kCVagskyAIYmIwHBb12VcTlebaInCc2rv1meWNAACe48z33IkyHFYeHMfp/V/5RhUYv6iPZ7YsO+vQuANVlHE5d/2jUTy5Vk3XNPZy5UMfaTAONxJQhUyyTNKkc6ddq9BpQTwhm3IYY4aeO0D9nZtzWtPm3Ampc+78YRGKAgymie7MtEweigJToywScjIUZay0TObcDQTSnTsSd0fC0Th3ywFcw3FcO4A/Qi3H/AWAYo7jmLdfB6Bb+3s3gEkAoN1fBGDoKK5PTECWNJaifSiMfsMbQPqcOwcNMScIgpgwDIfjKHFNbOfOY7fgmnk1+OrF0+HVki7HM+cumpD0QdOsPDOap4/LKGDMuk5A8jP7SMoyzQzrZhjXN56xC8yRHImI45rFl5AUuOwsvdLc68HcPlaqGjY5rw6A7sKZDWPJLMtkPXfs96GK7cFgquiW0gJV2Ea6ZGLjICHJptIyh0KZzp2atEllmUfCEb9qiqJ8S1GUOkVRGgHcBOBtRVFuBfAOgOu1h/0LgJe0v7+s/Qzt/rcVs1tKBKGxqLEEALCp3a/fxt6I2e4QlWUSBEFMDGRZwUiEnDsA+MVN83H3OZP1n7lxzLmLickv/m5NoOQTDPGErL/ukXGUZbLP7KHg+Ech5IvtT388wz8OIcnKEGUFCIwjVEWUZH1GnlnnTtSdO03cxcyLO5vu3FlMlcVmjkJgPXfqGliZ7FAwnuL4JtICVdifZvruMkYh5Om5GwjGdEEtSrLer0eMj+Mhif8DwFc5jjsItafuCe32JwB4tdu/CuCbx+HaxGnO7Joi2C08tnQYxR0LVEmWZY63fIMgCII49RiNipAVoHiCO3fZOGLnTvszX6mfKMm64xQyIUoYrPTQNy7BpUBW8sf2p1zH8OTH4xKKhuOGx1GamZAVeOyauMuRCpmOZAhUAcz1LmaKO/POnU0wlmWmzrkb1F6juCRjNJJch6QJNJaByEShmb67hCSnjkLI03MnyYr+u5Lk7EPMifwck/HuiqK8C+Bd7e+tAJZkeUwUwA3H4nrExMVm4TGl3IMD/YZZKGllmezNNRRL0Ac+QRDEacywNjC6eIKPQsjGeObcRUXJ0MOlfoaace4cVn7cfe5MFIxH3DFRN56yTCYknFZhXNcy9r0NheJo8LrzHqMo6vgDj4M5d+MMVNHFnbmUUoHndOHjtAkYNZHsGU/I+lw8wNBzx8oyDU7qQDCGIs2VFdPmzenOnQkX1ewQc38ojooCO/oDMfSNRlFeYNdGIVBZ5pFArxpxyjGt0oODBnEXTyvLZG+u440xJgiCIE4tWOjFRB+FkI3xzLmLJWTduXPZWFnm2J+hLKDDZRMQGlf5YlLcmY3UT86QG79zV1XkGFdZptGR2p82ein3+tRj3PbxlWUm0pw7M69jTEx14Nw2S96yWElWtMCXZFqm12OHVeCw9ZCaQG4cKm/su5MkRXfrAKNzl/85JqRkKIrNImQV55KsYDgi6uOurvq/NdjQ5oMkyxSocoSQuCNOOaaWe9A9HNHfBBNpZZmFJO4IgiAmBCwog6o0MlHn3Jl7bFQ0BqqY77mzCTxc9vHNlmUCTVaQEo429jFKyp9mYN8NygvsCMQS5kNOJAUNXhcK7Bbs7BkxdQwTqW7bOANVDEPMAZOBKlKqA2emLDO9lJNd8/LmavxtSxcicSmldNUo7hJp5ZEs5MSMMDeWVjqtfFbxur8vAEUBzprsxZKmUjitAp5d34GERGWZRwqJO+KUY2qFBwDQOhACYBiFwJw7u/omGYiOb0YNQRAEcWrBeqKoLDMTs2WZiqIgaghUcZkVd1o/lctqQWgcgSoJSdbFTM9wJM+jVdjnvCQrphMsmRCsLHQASJbw5l2frD6vWTWF2Nk9au5amovlHmfPnR6oom1Kmw1UMTp3Lrt5cWdMywSAW5fWYzSawAtbuzEUjKG8QE1aHQwYnLu0YeJ6EIuJ34MoJ3vu6ktd6A/EEDQIvL9s6sTlv1gNAKgrceLPn1uGa+bV4O09/QiLEg0xP0LoVSNOOZi4OziglkvoaZmafc8GpAbHUSZCEARBnHqwL+wTfRRCNtRAleQX8PWtQ7jrtxszXDZWKpcsy2Q9d3nKMrX0RTPiwoioOWMA0OU3J+6MvVqiiXJA9Trq4yo1wTJkcmh6QitDbK4twp7eUVOz51goiWfcZZmac+caX6CK0YEzk5bJnERbmrhb0lSKuXVF+OW7B9E3GsWUcjcEnkuZdZfu3BU61edoptTV6L5Nq1TLLllbjSwreGxVi/5Y9m/4suYqBGIJSIa5gcT4oFeNOOVo8KpvPuwNQpRkWAxJTh4SdwRBEBMCf1gExyUDKYgkxrRMUZLx7Rd2YOXefjy/pSvlcVExcyg2kD8tk81NM5vWyEjIMupLVXHXM2y2LNMg7kyWZjLhxJw7s0PJE7ICi8ChubYQsYSMFq1KaMxjJObcqa+d2XFMSefOfKBKLG0YudMqICrKY5ZJpg8+Z3Achy9fNA1d/gi2d42gzGNHqduWUpZpDNsBgLoS9XfX6QvnXasvFEepJtqma+Juf5+6Mf/itm60DITwrctn4F+WNWBBgzrq6uypXixpLMW182txy9L6vNcgMjkmaZkEcSKxWXjMqCrAxjZ1HIJoiNoFgAJt58xMetTR8s7efsytK9KHxhIEQRAnjv7RKEpdNurNyYLDKuDwSBSHhsJY2zKIloEQSt02PLmmDbcuqQevvWYsSZI5J+Mpy1RFBgdfyJwDB6iCpthlRZHTaros0xhyIiZkwMRHLhNOFYWac2cyVEXdMOb1lMzu4bAe9pHzGPkIA1WktEAVs86dMVBFE5QRUdKdw3RiWXruGOefUYFr5tXg5e09cFgF1Je6cKA/iPtf24t4Qkb3cAQ1xU798ZM0Yd7pH1vcKYqCgUAM5drrX1/qgs3CY82BQRzoC+DpDzqwsKEEd65oSvkOZ7cI+PO/Lsv7OhC5IXFHnJJcOKMCD79zEP5QHKIhjQkACrQdsOBxFneDwRg+89uNOGdaGZ65a+lxvRZBEASRyf6+gF6qT6Tyb+dNwcq9ffjMbzdA4FUn6s7lTfjqn7djW9cwFtSrTsnhEdU9Yw4XC1TJN96AbaxaBXPlhMbjLDyPmmKnaXF3NGWZFQXq8/KZHJrOEh6ZyI2a6J+TMsoyTQaqyDI4ThXUHJffLVXPLcNuTaZeOg1ltLnEXa6eO0B1735+45lY3FiCZVO8+MumLjy5tg37DwfgcVjAcxyWNpXqjy9yWlHgsKDTN/bvbjSSQFySUa5tfgs8h8llbry8vQdWgcPZU8rwi5vOpL664wC9osQpyQUzKyErwLv7+zOcO4eVh8BzRxWo8v1Xd6Pxm38f8zHtg2qphtk6foIgCOLYoSgK9vcF87oqE5WpFR48fPMCtAyEsL8viNuWNuDc6eUAgPWtPsQTMn757kEcHFBbHKqK1C/hNkH9DDXVcyccQVmmJp5qi53oHmegivp3k2WZ2uPKC+zgOfNz9VjCo8NirjwVSApO1q84nkAVK8+D4zi4bRZTw+DjCQn2lFEImtM6xrGsr9JuEbLez/McPr2sEVMrCrC4sRSipCAQS6B3JIrekQjqSpwpj59U4srr3LEk1Apt0wBQS4UB4IHr5+HpO5dQyu1xgpw74pRkbm0RKgrsePDNAyh0WlLEHcdx8NgtR9Vz98SaNgCpMb7psLTO9Dc9giAI4vjTMxJFMJYgcTcGK6aV4eYlk/DPXX245swauGwWTKvwYF3rECaVOvHT1/dhmuZ8MueO4zhtdp2JUQgWHg6rgPA4Pm8TsgyLwKO22IH1bUOmjjEKOtFkyaMoJd0qr8eOAZPOnSjL8FgtuoMZNeHCMSHptArgufGUZcqwaJVHLpuAiGiuLJOJSHYcMHYZbUzMHqiSjYVa7xtDVpJ9doxJpc68vYgDWuJmuaFt5b8/PhtrDw7h42fW5F0HceSQc0eckvA8h4dvWYCIKGFn96j+5sgocFiylmUqioIfv7ZHd93yMZb716LtdpYVUL8dQRDEiWbfYTWm/oxKEndj8YNPzME73zhPFwRnTfZiU7sPr27vBQAc6A/CbRP0lgZAExome+5cNgFhUTI9dkF1qzhUFzsRiCZMbcQmUpy78Q0ItwgcKgvtevlp/mupaZnMuTNTlqmPZBI4OKzCOMoykwPCzQhqwNjrqMLKMscShnEpd1lmOiVuG2ZVF6LMIMqyOXdd/vCYv/N+TdyxnkcAWNRYinsvmqYH4BHHBxJ3xCnLkqZS3LR4EoDMXTKP3ZI1UGUgEMOvVrXirT19Y56bvdmONReHiTuzu4gEQRDEsUGWFWzpGAaQjFgnsiPwnJ7GCADLp5YhFJfw+q7D+m2VRY6UY9w2C4KmyzItUBRzIogJLqvA62OLsg22zriWQdDFTYo7JrisAo/KAgf6Rk323MkKLAKvDwo3k3yZfF4c7BbetHNnbCsxM9IAyBKoojl3YwnDbEPMx+Lx2xfieUOoSaZz50JUlMd8TXXnjjbATzgk7ohTmrMmewEk30QYhQ4rgrFMYRbSdiLz7Y6xMoeRSG5xx8oyoyTuCIIgTijffXkXHn7nIBq8Lj1pkDDHJbMqccfZjQCAKq0Us7IgVdxVFzvQPcYMOkVRUpw7wFyoCitftAi86VROILUsM2Gy506fgcvzqCh06D1g+deojleyW3hwnElxx5w7nofdIpjuuUtIil555DY5L1ANVDE6dybKMscp7upKXGgsc6OmyAGeA6rSxP+C+hLwHPC5ZzbldF77A1E4rLyeYE6cOEjcEac0LO0rHY/DgkAW5459+OT7EGJxxsM5xF08IaNDm/ESMznPhiAIgjg2bO7w48xJxfjz5ygyfbzwPIfvXj0LG79zEa5dUAsg88t7U5kbrQPBnGV3CVmBokAPVAFMijSZuWkcnFZzw9KB9EAV8/1sQLIsczAYN3Usc+44Ti3NNBOoopeA8hzsVt50WaYoq8mhgOrcmSlRzXTu8r+OybTM7IEquWgqd6Oy0JEhCufUFeGRWxZge9cIXkibm8gYCMRQXmCnEsyTAIk74pSG7VilkytQhb1J55slk8+5Gw7H9YGh5NwRBEGcOBRFQdtgCAvqS/QQEGJ8cByH8gI7ppSnhqkwmso8GI0mciZM6iWPFl7v5TMj7nTnjudMD0s3Xg8wX5ZpLAFlzy+9yif7cTKsWmuG0yaMK1DFIvCwW3hTJarsODbKyeu2mUrfZkE2DFOBKgnzgSpGvnTBNNx35ays910+pxozqwvx/OYuKIqCV7b3pKSf9gdi+hgK4sRCXilxyrPh2xemDDgF1ECVkYiIPb2jmFldqN/O3vzGigwGks5dLnEnGq5npmSDIAiCODYcHo0iIkpoKnef7KWc8kzWXsOqQnvW29sGQ/B6Mnum9B4ugYdLG6JtZgB30k078rJMs6MQ2BqtmnMHAH2j0ZSB3NnXmEzJdlh4M1mzsgAAIABJREFUROImAlXkpEtotwh4e18/Lvjfd/HKF1fo3yeyXktLDgXU3rSBYAyKoozpdqWLO6cJkcxeY9s4Z8qx1pdcXL+wDt9/dTf+65Xd+O377XDZBFgFHl+/ZDp6R6IUdnSSIOeOOOWpKHRkvFl7HBYMh0Vc/ovV6PQlZ7GETTp3Tm1A6Eg4x66lwa2jskyCIIgTR5vW7zy5jMTd0TK7phA3L5mEC2dWptzOXtvWHMnSxoAOl9W8A8dcN5vAm+oVY6SUZZodMyDLEHgOHMfpDpKZUBVRUnTB5Rinc2flVecunpDROhDCvr5A/mtpQrK8wI54Qs4aBmckJqU7d1owTY7vNZG4hKfWtqPR60Kp+9jOlbtuQS3qS1347fvtmDepGJc3V8NlE/DIOy1oGwxhUWP21hni+ELijjgtMTpzbEArkIwKzvdhwgZt5nLuErJB3FFZJkEQxAmDCY7J5NwdNXaLgB9/ci4mlaamIdaVuCDwHL7/6m78LUtPlTGggzlT2frc00mWL3K6KDEz280o7oyfv/muxYQT6ynsG80fqpKQZb1U0mERTG3gGvv7jGEnLf3BXIfox1kNzh0wdumoPxRHPCGn9M4JWvhLJC7p/zGiooR7/7gVh3xh/OiTc3LO7T1Sil02/PXfzsYdZzfioZvOxP9+ah7uWtGEw9rrfOnsqmN6PcIcJO6I0xJjKUGHYeeRpWTma1pmHyS5RiGwshCbwOcsy4zEJQyZHJpKEARBmKNtMASnVchIeCSOHQLPwW0TEIgm8I3nP8TO7pGU+0WDA+f1qG5Qrv48Iwn56Msy42bLMqVk8EipywYLz+miYywkQ1mm0yYgMu5RCEnhZdxcznUcS8tkw75zibtdPSOY//03AWTOq3PbLQjFE7j2l2tx9v0r9SCcn725H2/u6cN3r56Fs6eU5X0eR0J5gR3fu2Y2GrzqZgsTdLNrCjM2DYgTA4k74rTkyrnVOPDDy+G2CWgfSpZlRkz23LGeupzOnfbh4nFYcjZO3/X0Riz8wVumBrsSBEEQ5tjfF0BjmRv8MXYhiFQeu20hHrxxHkpcNvzXK7tS7tPLKy28XurnC5kreQQAK88lyzJNDO4+orJMw5gBnudQ7LJhOEerRcq15KSb5rCaC0dholXgeThSnLvsZa36tSQZVj7NudM2hdO/OxgFdnrvXLnHjp7hKPYeDsAfFvHgm/vx+s7DeGFrNy6eWYnPLG/K+xyOFZNKXfjM8kZ84fypJ+yaRCoUqEKctlgFHg1eNw4dQc8d+/DIOQpB+6Dx2C0IRLM/5v2WIQDAwf4gDdklCII4BoyERaxrHcLtyxpP9lJOe86eqjo9PcNRPPDGPvSNRvXUSWOgit0ioMBhwaCJpEfjYHHWq2fKuTMIOtOjEAxhJQDgsQt5Z9wCqeWcTqsAfyj3vNvkmgyjEAzOXWs+505S9P45Y1nmk2va8NT7bXjjy+fq5attg8nvMumplzOqC/Dm7j7954fePqj//Zoza/Ku/1jz3atnn/BrEknIuSNOaxrLXGgfSu6chU323LFduNGczl1S3OXa1ZtXVwQAWHNwcHyLJgiCILLyxq7DECUF18w78V9YJyoXzqwAALy9t1+/LZ42FNvrtmHIRFmmaOi5swg8bAKvfy6Pfdz4xZ0oKanz4OwWhPK0ZCiKos+5AwC7dZyBKoI6+BxQhW+HL4xYQsLKPX2Q5cwqHtFwrSKnFVaBw0Aghn/uPoxOXwS/X9ehP7bd0GKSIe6qCvXvNd+7ehZ+ffsiTC53w20TcOGM1LAc4vSHxB1xWtPgdaPTF9Zn0ulz7vL23KmPz9Vzx+rrPQ4Logkpa+llhbbDuZbEHUEQxDHhlQ970OB1Ya62eUYcf86oLEBtsRMr9ySdobjBgQMAr8cOX0iN8X/gjb3Y3TOa9VyJtONcdnNDwuNHMApBlGS9LBNQxV2+fnvJMIwcUANVoqaGmCcDVdim8IKGYkiygj9t7MRdT2/C67sOZx4nJWfqcRynlVdGsPXQMADgV6ta9eHkxo3q9ILkGdXJ6qCr59Xg4lmVePbupXjunrNyzgMmTl9I3BGnNQ2lLoiSgh5tsCbb2YolZP1DJhtsZzDnnDvt/gK7BYqSfagqe8wW7U2aIAiCOHIicQnrW324eGblmHPAiGMLx3G4ZHYl3ts/iF++exAX/2yVLshSnLtgHAOBGB55pwUvbuvOeq5EmnhyWQWTw89l3REzXZZpKK8E1EqbfC0Z+voEFqjCI2qix080jEJgm8IrtLLWf+zoBQCsPpC50WucqQeopZnv7O1HLCHjnnOaMBSK4/frOiDLSoq46zC0mwDAzCp1nq/XbdPnElYXOTFvUnHetROnHyTuiNOaaZUeAMC+w+qsmbDhjT08RgIW+/CIiFLWNEzREKgCZB+HwMo0gibioQmCIIixWd82hLgk49zp5Sd7KROOm5fUIy7J+Onr+3CgP6g7Syy10euxYTAYR5tWOnhoKJz1PKKUTMsEtDRKk3PuWI+e+bLMZDAKwMoy87VkJEUaoDl3JtIyJRaoInDwa6Ety6aoqd0b2nwAslfxGMNbAFXcBTR38bPnTsE508rwq1WtaBsKISrK+NzHJgMArpxTnXKeykI7SlxW/TsPMbEhcUec1sysLgTHATu0lCnjDuFYpZnGHb9sfQTGnjsAWd/8mZsXl3K7hCM5yj4JgiCIVFYfGITNwmNJU+nJXsqEY3plAZY0Jl/3tS2qUEk6d3b4w3F9BuEhXy5xlxwjBKgDuMN53DRALctk5YVmRyGkizuPXchblsk+q9NHIeRLvTYGqti0QJVJJS7UFDnAWu0O+cJ4Z28/DvYHIMsKNrX70DoQSikdvWlxPebVFeGy2VUoL7DjyxdNw1Aojv98cScA4Nxp5Wi//0o016aWJXMch29ePgOf+9iUfC8LMQGgtEzitMZls2BKuQe7erKJu9y7cXFJRlWRA13+CHzBOGqLnSn3i3Kac5clVMW4uxhNyPCkRRd3D0ew/P638Z9XzcJdK05cTDFBEMSpyOoDA1jSWAqHlXqITgb3XTUTG9v9ePr9dt25S/bc2SDJCrZ3qrd3+sJQFCWjfNY47BtQxZO5OXfqzDqrwI0jLVNJ7bmz5Q9U0csr2RBzq6C3XhhTMDOuZQhU+dVtC/HWnj5UFDowpcKDnpEoFjaUYHvnMD7z240AgNvOqscfN3QCAATDa3TRrEpcNCsZgLKwoRTnTCvD6gODmF7pwYL6kpxruHFx/ZjPjZg4kHNHnPY01xRiZ7fa3B2JS3rd/li7hQlJQZUWiDKYZXZPwtBzBwCxLGlaKeIui7PH5u38/M39Zp4GQRDEhKVvNIr9fUGcM+34DGIm8jO3rhh3rWjCHM01qi12orpI/Zxks+42dfgBAIFYImsgmSiniieX2SHhkgyrhYeF58fsl0+5lmGGHKCWZYbjUtbUSoYeqKLPuVMFXTQ+9jUTstoTKPAc6r0u3Klt2E4pV8skL5hRgQ++dSGevGMRlk/14vfrDkFWFPz7ZWfgnnMnj3nu+66chcubq/D0nUsoHIUwBYk74rSnubYIh0ejGAjEEI4nUOpSP4TGcu5ESUal9qE1lGV2j5hRlpm75w5A1p4C9iESiCVo0DlBEMQYsDCKc6ZRv93J5tr5tWjwuvD0nYt18VOmhXgc7A/qpZrZSjN1545nZZlmnTsFVt25M/d5mZAUWC2pgSrA2HNuxbSyTDaQPN84BFFSUoQkY2qFKu6mlLtRXmDHBTMq8a3LZwIALp9Tjc+fNxUzqwvHPPcZVQV49LaFqC5yjvk4gmCQuCNOe1ha1NqDgwjHJf1DKJdzx+bcMOfOl8W5SwaqWAGM3XMH5Hf22nM0nxMEQRBqSWaZx4YZVQX5H0wcVy6aVYlV3zgfUyuSvwuvx6b/fanWE5ld3KWlUVotJkchyFo/G581nToboiTrIhJQnTtg7I3dRJqz6NTEa741SnLq2AXG8qllaK4txMKGZL9ic20RnrxjEb579SxTz4MgxguJO+K0Z2F9CRq8Ljy3/hDCcQnlBaq4C+V4s2bCrdhphd3CZ3XuMgNVsvfcsbLNSJaSjngiufu4sd03nqdEEAQxYYiKElbtH8CKqWXgeRqB8FFkekUBblw0CQDw8TNrAWQXd0yYJQNVBFOBKqIkw2bhYRV4iCZGE6jHKLpIAwC3XRVqY4WqpDuLelnmGM7daFTEQCCWMtKA0VTmxqtfOkf/3sG4YEYlKgocpp4HQYwXEnfEaQ/Pc7hlST02tPswEhFR5mFlmdnf4NkwUquFh9etxjtnPkYVZgWOMXruEgoKnaqzl62nwLj7mK/JmyAIYqKwp3c0pVT9b1u6MRwWKTDiIwzPc/jJ9XPR8qMrcP3COjSVubG+LXPTMhmokhR3uTZaU49jZZm8/vmb9xg51bnTyzLHEnc5nLtsG7iAKjpv+tU6vLitJyWZkyBOJvR/IjEhuG5hnf533bnL8QYvJpKpV16PHUNZyjLjZnruZFkXf1ln5Rl2H+MmdyIJgiBOZz5oGcLlv1iNd/cNAFDL5J9Y04rm2kKcNZlGIHzUYe7VJbMr8f7BwYxxP5lDwgXEE7Leg56LuCTDKnCwCtw4yjIVWC3Jr7kumwlxp1XuCJootGs9d7nKMn+9uhW7e9XANl+WsUkEcTIgcUdMCMo8dsyuUZuWywvsEHgu6/w6QB0qCqg7d16PLesbdiJtiHnWnruEjEJHbufO2HNH4o4gCAJ4aVs3gORs0v19QbQMhHDzkvqMWH3io8tls6uQkBWs3NuXcrs+akATT25NcOUrzWQz68ZXlinDymcGqoxVlsk+/y3pzl2W6py+0Sj+b+VBLJ/qNbUegjhRkLgjJgznTldT1gYCMUyr8GCPttuWDhNdVoGH120fs+eOfTBle+MXJWVM5864+2h2J5IgCOJ0JZ6Q8drOwwCAfYcDAIC39qji4KKZlTmPIz56zKsrRl2JE4+/15qykZmQkpunAPRo/3yJmSnizuycOyltzp09/7WYg8jEp74+QwjL4ZEooqKEB97YB0lW8ONr55paD0GcKEjcEROGm7V+jfPOqMDsmiLs7B7JOoJAT/PiVeduMBjLeJwoq43aLCY52xDzfGWZcSrLJAiC0Nnc4cdIREShw4J9fQF82DWMv3/Yizm1RagspPCJUwme5/Ddq2dj7+EAfr26Vb89fdTA9Eo1cfPtvf1jni+hhaNkG4UQS0hoGQhmHiPLKX1w6c6dLxRH32g05Zj09U0qcUHgOX0zWJIVnPvAO5j/32/i+c1duHNFE+q9Lmz5z4ux6hvnjfkcCOJEQeKOmDDUe11ov/9KPZp4MBhHfyB3P51NC1SJJeSMnT4xoX5o5ErSUhQFomQIVMmyU2j8gIqRuCMIYoLTMRQCAFw4sxIH+4O45uG12N07isuaq07yyogj4eJZlbhoZgUefbcFf93chdd29Oobo6zEdnFjCWbXFOI3q1vHHC4el2RYNOcuvdLlD+sP4fKfr8ZwOLXKJp5IFXfutECVf39+O+5+elPKMWxzlzmLbrsFzTWF2KAlWu89PIp4QkZElNDgdeHeC6cBUIe4N3jd43uBCOI4QeKOmJA01xYBAHZqfR1Gks4djwKtZy4QTa3RT8gKLDwHu9asnR6owoSb7txlEW9sh5DnYLrMhCAI4nSlyx+BwHP42PTkoPIXPn82Pnvu5JO4KuJo+PJF0xGIJvC1v2zH55/bgpe39aQkWHIch7vPaULLQAjr2oaynkOWFQwEYihxWeH12DCQtim7ry+AuCRjT28g5Xb2Oc1w2QRwnCruEpKMD1qGsKd3NCXtWtIDX5JrXNRYig1tPtz8+Do8tPIAAOBnn5qHZ+5cqpdtEsRHCRJ3xIRkVnUhOA7Y2Z3ZdycaegJYjX4ordmb1f9znCrwYmlll6KeppnbuWOlmG67JWdZ5v2v7c3YWSQIgjgd6fKHUVXowJw6dfPtU4vqML++hCLmT2Gaa4vw2XMn446zG3HmpGJ0D0cgpbU5XDa7Gi6bgFe292Q9R/tQCIFoAnNqi9DodaPTF07ZEO0YUufp7T2c+nmu9tylCkm3zYJgTMLewwGE4hISsoKD/cmSTlGfc5cUhYsb1ZTWD1qH8MauPtQUOfDJBXWo97qO5CUhiOPOEb9jchw3ieO4dziO281x3C6O4+7Vbi/lOO5NjuMOaH+WaLdzHMc9xHHcQY7jPuQ4bsGxehIEMV7cdgsml7mxsyfTuTMGqrhzRCcbG7WdNiEjDZO5f3YLD7uFzxq4YhynkCtQ5bFVLXqgAEEQxOlMlz+CuhInppR78MLnz8aPrp1zspdEHAO+fcVMfO+a2fj6JWcAyOwxd9oEXDyrEv/YcTjrRidLTp1bV4zGMjcSsoIuf0S/Xxd3BudOURTEJRk2ITVh1W0XsL1rOEVI7ukN6H316aMaAOCsyaXwum24aGYFAGBxE43kID7aHM12WALA1xRFmQXgLABf4DhuFoBvAlipKMo0ACu1nwHgcgDTtP8+C+DRo7g2QRw1zbVF2JWlLFOPahZ4vUY/PTqZOXcA4LIKGT15cYP757QJiGbtucvv3DHyxUQTBEGc6qjiTnVD5teXpLguxKnPssm5RwZ8ckEdRiIibvvNerQPhvBvv9+M91sGsa1zGKv2D8Bu4TGtwoPJZWpfW/ug2p8ZT8joHVGFntG5y1ZeCQDXLajD9s5h/Oq9VtQUOWC38Pj6X7bjkgff03rlmXOXPK7YZcOm+y7C459ehDvObsRtZzUcg1eDII4fliM9UFGUXgC92t8DHMftAVAL4OMAztMe9jSAdwH8h3b77xR1e2Qdx3HFHMdVa+chiBNOc00RXtrWg6FgDF6PXb+dRTVbBA6uLDHIAEvLVN/8HVmcO6P757Bk3g+oH0qsby+fuOv2RzBNSxUz4g/FUeK25XuqBEEQH2niCRl9gSjqSpwneynEcYLnOTxz1xK0acLMyMeml+N/bpiH77ywA1c8tBrhuIRV+wf0jdPJ5W5YBB6NmrhrGwzhY7KC/X0ByIoaaLKvL4B4Qsa7+/px9tQyAKkOHAD8+2UzcPuyRjy3vgNTKjy494/bAAAH+oPY2T2aHIWQdhzHceA44HvXzD62LwpBHAeOybYYx3GNAOYDWA+g0iDYDgNgw2lqAXQaDuvSbks/12c5jtvEcdymgYGBY7E8gsjK7Fp1qPmuntQ6/bixLJOla8XTyzJlvSbfZRMyeuqM4s5pEzICV9hjrAIPmyUz/SudTn8447ath/yY//03cd+LO7KOdMhFz3AEP/rHHvz4H3vGdRxBEMTxonckAkUBibvTnHOmleP2ZY1Z77t+YR2+d81shOMSrppbDavA4+JZlXDZBFx7pvp10eu2ocBuQftQCN99eReu+r81AIBLZ1ciKsp4aOUBfPaZzbj/tT0AAFsW97eqyIGvXnIGPn5mLe5a0QSHlQfHqTMVWUuFwHMZxxHEqcIRO3cMjuM8AP4K4MuKooyyeFsAUBRF4ThuXN8eFUV5HMDjALBo0SL65kkcN2bXaImZPSP6gHMgNQrZo0cnZ4o35tw5rUJG2aRe2qn13GVz7kRJgc3CwybwOUchFDmtGImI6PRFMu5j83l+v+4QLptdjRXTyvI/aQDPru/A4++pc4e+cMFUFGqJoARBECeLdq1vipVlEhOTmxZPwpzaIsysLoQkq5+RxhEJHMehscyN91uGUhzAGxfX4w8bOvHEmjYA6ucikBqMko37rpyJb14+Azc9vg5/29qFArsVFp5DgZ0+F4lTl6Ny7jiOs0IVds8qivI37eY+juOqtfurAbDJlN0AJhkOr9NuI4iTQpHTiqkVHry7L9UhNrpurCwzPVBF1AaqAoDTZkEkYxSCdg5e67nLIu5iiaRzl2sUAhul0OnLdO6MbiCbwWMGY39gtnURBEGcaJ5c04ZChwWzagpP9lKIkwjHcWiuLYLAc7Bpo4Z4ngNvEGnnnVGOg/1BWHgOd69oQnNtIebVFWFymRsRUcLZU5K9ffn6NjmOg1Xg8alFdegbjcEfjuPhWxagyEXijjh1OWLnjlMtuicA7FEU5WeGu14G8C8A7tf+fMlw+xc5jvsjgKUARqjfjjjZXDu/Fg+8sQ+HhsJ6rLFoqLlnaZnpgSoJWdY/NFxWAYdHUp21lLJMa3ZxJ2pJXjYhd88duz1bWSZzA4tdVmzrHDb3hJEqCmNZykUJgiBOJB+0DGHV/gHcd+VMFDnpSzUxNl+9eDrOnV4OSVZwliGkZfnUMrQOhnBZcxU6hsLoHo5k9M7l4sbF9bhxcf3xWjJBnFCOxrlbDuDTAC7gOG6b9t8VUEXdxRzHHQBwkfYzAPwDQCuAgwB+DeDzR3FtgjgmXDu/FhwHPLqqRW+kThjSsnheDVXJVnbJyj2yjULQxZ2Fh8OaPVBFlGS1LHOMQBVWrpmtLJMJxmWTvdjeOWy6f844sPV4OHcjYRFXPrQ6ZXYQQRBELt7e2webwFMKIWEKjuOwuLE0RdgBwGXNVbBbeJx/RoXu3o1ExJOxRII4qRxNWuYaALm2RC7M8ngFwBeO9HoEcTyoKXbi5iX1eG79IfAc8MNr56QIMwBwaUNPjYiSrPfjObMGqiTdP9W5O7JAFSbEfKF4xn1MMC6b4sVrOw+jbTCEyeWevM/Z6NZlE51HS9tQCLt6RrGtcxhTK/KvhyCIic2Gdj/mTSqCwyqc7KUQpzDLp5Zh139dCovA49oFtfjL5i4UOylNmph40BAZYsLzw08044o5VXhzd58250YTZpoz57EL2YeYM+fOOnZapiPL/YBacmkV+JxlmYqi6M5dtjl30bgEjgMW1JcAAPYeDmQ8Jhupzt2xL8tkbqA/iyAlCIIwEo4nsKt7BIsbaTA0cfSwdomzp5Th7a99DNctrDvJKyKIEw+JO2LCw3Eclk32oj8QQ/dwJEWYAeqQ8cyyTEPPnU1AWJRSyiJTxR2fIqgYcUmBdYyyTFFSwE6ZzWGLiBIcFgHFWuN3MGpu0LlR0KWXZUZFCZ9+Yj12Zhnubha2Vl+YxB1BELmRZAUvb+tBQlZI3BHHnMnlHhppQExISNwRBIAFDar7tbnDr49CYMNP3TZLlkCVZFqmwypAUZAyziCeSC3LzObciQkZdiG3uGOCsMhphSgpGYmaEVGC0ybooS/Z3L1sREVJDy1IF42dvjBWHxjE+jbz6ZsZ6ybnjiAIEzz+Xiu++bcdcNsELGwsOdnLIQiCOC0gcUcQAM6oLIDLJmBLhz9liDkAuO3CmHPu2LgEo4BLyOo5bNoQ80iasweow9KtFi5nzx0TiyWaMxdOE4iRuAynVYBTu37YZP9cLCHrbl+6c8d6+45GmOnOHYk7giDG4IPWIUwpd2PtNy+geZsEQRDHCBJ3BAG1Tn9BfQnWHBzMWpYZimfruUsOMQdSxRU7h0XgUeS0QlaA0UhmaafecyfJGeKPibsil9oQnu7+RUUJDqs6JJ3nMu/PhdG5Sx+F4NdKKY+mpJKVffrTzvH3D3uxo+vIyz0Jgjh9kGUFWw/5saTJi2IXhV4QBEEcK0jcEYTGVXOr0TIQwuYOP3gOeq2+22bJMsRcNgwxz3TuRENZZpnHDgAYDMVSzhFPyLBp4k5R1FJPI6y8Mencpa4hqpVlchwHl82S4ezlIpaQc5Zl+kJqbHS6c7e/L4CuLLP2RiIiNqYNUGevgz+cGkH9hee24OqH15haI0EQpwfPrOvAprT3iD9tPISLH1yFQDSBhQ1UjkkQBHEsIXFHEBpXzK2Gw8pj9YFBPSwF0Jy7tLLMhKzoPXkurefNKO5YmaVN4JPiLpAq7kRJ1gNVAGT03SXLMjXnLk2IsUAVQBWYZsVdVJT0nfL0skzduUsTd1/50zb8+B97M85134s7ccNjH6A/EE1ZF5C7tJPmDhHExKDTF8b/e2knHlvVknL7D/6+By0DIQDAgvrik7E0giCI0xYSdwShUeiw4rLZVQBUUcbw2AWE4onUNMxEsueOlWUaxVfCUJZZVqAKqaE0sROXNOcuj7hj/XHpZZcsUAVQ+/4iJgNVVOdOFaTpoxCYqBtOc92Gw2LWHjomWLd0+JPnZ+IuHIesuZGywZV8b/+AqXUSBHFq8+z6Q1AU4ENDOXYkLunvZVMrPGgqc5+s5REEQZyWkLgjCAPXL5wEIJmUCQAuuwWKkireRNkg7ligiUFcGYeYe92acxdMc+4SSqq4SwtVSZZl2rTzpweqSPrQX6d1fM6d22aBTeAz3EDmtqX33IXjiYy+QwBoKle/mG1oS4o7dk5ZAUajYsptALCKxB1BnPYoioLnN3fCJvDoD8RweER197d1DiMhK3jqjsV48yvnguMoqp4gCOJYQuKOIAwsm+JFTZFDF26AWpYJIGUcQvoQcyB7WaZV4FHqtoHjgMFgqmASWVqmkK8sM3taZlSU9Gu7tETOfLDB6HYLD7uVz0zLDCfTMo1OZTguZYyDUF8HdY2bOpI9NUY3kLl9RmHYMxzJu06CIE5tOn0RDAbjuHpeDQDgw65h/Pi1Pbj51+sAqONnSNgRBEEce0jcEYQBgefw5Yum4/LmKv22miIHAKClX+0RURRF67lLG4WQJS3TKvAQeA6lLluGcxfXSjtzOnfpaZliqriKpIg7c4Eq7Jx2qwCnVcgYrs6cu4SsIKCJOUlWBWG2Iekh7Zq7ekbxyDsHIctKyuvAevjChp7FoeD4kzgVRcHP3tyPPb2j4z6WIIgTz84etRTzU4vqIPAcfr26Fb9a1QqB57CkqVQPdSIIgiCOLSTuCCKNTy2ehP/+eLP+85KmUgg8h7UHBwEkSy5taWmZRnGVkJSUxM0yjx1D6eJOSqZlAtmcu/S0zHTnTtav7bQJGYme2dDFnYWHI8twdV84rq+ZCT0m1rKdPxKXUFXowML6Ejzwxj60DYVS3MAuv+qtuNGIAAAgAElEQVTSMefO67Zl9B6aYSAYw0MrD+Bzz2zWb3t2fQf+tqVr3OciCOL4s7N7BBaew7xJxVjSWIqN7X5MLndj5/cuxR/uOetkL48gCOK0xXKyF0AQH3UKHFbMqyvCS9u74bILuH5hHQDozh0TWNE0585Y2un12LKWZdrGSMuMp6dlZglUcYyzLJP18TmsAhxWPiNQxR8S0VDqQutgCL5QHA1eN8KaqAvFJciyAp5PllKF4wnUe134/HlTsOEpH4bDcURFCRUFdgwEY7j3j9tgFXiUF6h9h3WlLuzsHtHP8/rOw9h6yI9vXTFzzHW3acl67LUCgGc+6IDTJuCTC+ryPm+CIE4sO3tGMa2yAA6rgGfuWoL9fUGUF9j190uCIAji+EDOHUGYYPnUMnT6Ivjp6/vw/Vf3AEBGz104refOmLhZ5rGnlGUmJBmyAlNlmdnSMiVZQTwhw2FNloaOqyzTwsNpFRA1lGXGEmpf3eRyDwBDSaXhvOmhKuG4BJdN0EusRiIiIqKESaUuvHbvOeA4YO/hgO76TSpxQpIVPWjl9Z29eGZdR951tw2q4q5cGysBqAmeLKQhG/GEjHf29qckdabzg1d347n1h/JenyAI8yiKgl3dI2iuKQSgboTNqinUN3kIgiCI4weJO4IwwbXza3H2FC8ub67CK9t7ACRdJKvAwypwGT13Vkuqc2fsNUumaY5Rlqmdz2O3wCpwCBvOz1xCp56Waclw9rIRNTh39rSyTL82wHyKloDJfk4Rd2nz/sJxNXmzUBN3o5EEoqIqOmdUFaLYacVQMKafo77UBSAZLjMSERGOSxnBLukwcVfgSBYbDEfi6A/E9FCXdN7YdRif+e1G/O+b+3Ke9+XtPfrvkyCIY8O7+wcwFIpj2RTvyV4KQRDEhIPEHUGYYHK5B8/dcxYeuGGefpuFT/7zcVoFjBqGcxvTNAHVuQvGErqDpQ85NzHE3G5Rw0+MQowJSeOcu3DaLL5spPfcRROZyZZTMpy7pFsXjKXOvwvHEnCmO3fxZNCL12OHLxRPOneauNPn6WmvWb4+PDbwmD3vqCghKsqQZCWl3NX4/Nk1H3mnBf2BKCRZwXde2IGD/QH9MSMREYd84TGvTRDE+Hj0nRZUFzlw1dyak70UgiCICQeJO4IYBx67BUubSgEAkpwURgsbSvDSth70jqgBIvG0nrtZWnnSts5hAMk0TZvA6eIulkPc2Sw8nJp4YzChp8+5swmQlcxzpGN07pxWXncHgaSYq/e6IPCcLsCMzl0w3bkTJbjTxF00kewFLNUCVNg5JpUwcaeWqI5ow9J9eRI02waDAICAlthpHLLOXvNfrWpB07f+ob+2AUO6587uERwejeLZ9Yewck+//lrEEjJ6RiIZqaEEQRwZm9p92NDuwz3nTE7pkSUIgiBODPTOSxDj5PZljQDUcQGM/7qmGZKs4Cev7QWgll0av9gsaiiBwHNY1zoEIOnSGcsyxYyeOwlWgYPAcxmjDtLLMvVxDHlKM5n4UwNVUkNYmJjzum0ocdmy99zFMnvunDYLrAIPl011L6OG4epet0117jRhmq0sEwCGQqlJokYSkqy7a+z6w5GkGGR9d4+/1woAWLVPHZLO+voAYCAQ051VvyYM2bUVJZnqmY339g/gukffx0hYRCiWwC2/XocDfYGcjyeIicwv321BicuKm5ZMOtlLIQiCmJCQuCOIcXLl3Go8e/dS3LykXr+t3uvCTUsm4e87ejEQiKF3OAKrkCzLLHBY0VxbpIs74xy8nGWZogy7hfXUCSl9aSzlMl3chfP0rrFz2C08HJbUczIxV+K2odRt1cWecb6e0Q1LSDLiCVm/dqHDqgeqJMsybWrPXUyCwHOo0mYG+rQh6aws02coy2wdCOKKX6zWR0cMBGN6jyIbpM76AQGgVxN38yYVAwCe36yORxiNiHrgzEAgpou5kUiqsASQszSzZSCI25/cgM0dfhwcCKBlIIj3W4bw3oHBrI83QyQu4bsv7dRdS4I4XVh9YABv7+3HZ5Y3wWWjMG6CIIiTAYk7gjgClk8t090pxq1L6yFKCq5/7H1s6vDjU4tSd67PmlyKrYeGcffTm3CgTy0zTOm5y5KWabdkT8OMiKllmeyLVCQ+9qw7JgodVgFOm5AyCoEJrGKnVXXuNAFlDFExOndMSDJxV+RUxR0LVAGAUrcdwxERgagIl02AzcKjwGGBLxRHMJaApLmfRnG35dAwdveOYke3OgSZBdHUlTj1QeojBueOlWUGNKdu5d4+iJKM0WgC5QV2FDosqc6d9ryMpZ2HhrKLu9X7B/S/+0Oivs4u//j69IyJnVsP+fH0Bx14v+XIBSJBfNTwh+L4yp+2YVqFB3ef03Syl0MQBDFhIXFHEMeIqRUFuHJuNRKSgq9dPB13rUj9gnP9gjosm+LFxnYf7v7dJgB50jITki7unDnEndOWFH9A+iB1OWMMAOsts1t42K18SlmmPxRHkdMKi8Cj1G2DT3PyIjlGIYRjTNypwpKJuxTnzm2DogDdwxG4tcexsRBGcWUUdwMB1bHrHlZFGwtbafC6EIwnIMuKfqzTKujOHbtNlBQMBGIIREUUOqwo12buMaduOItz15FD3BnXNRwR9Wt0+nKXcabz9w97Mfnb/8D1j76PqCjpZaGDwdylqARxqvHC1m4MBuN48MYzybUjCII4idA7MEEcQx65ZUHO+6ZVFuCZu5aidSCIax5ei2AsgQKHZcy0TLuh7LJ/NCkGsgWqAMDKPf1oLHOj0GHFdY++j8WNpbjvqln6cSnOnVVAPCHrA8V9YRGlbnVgeonbhuEsPXfGskwW8OK2a2WZTitateAThy1ZlgmoZY8u7XHlBXYcHommiKus4k7rg2PhK/Wlbqw9OISwKOnlnNMrPXrPnT8sorLQjr7RGPoDMYxG1Ne3gDl3aWEs7PkV2C040J+9h24wFIdN4BGXZAyH4xC0BNTxOHe7elQHclOHH22DIV00pw+1J4hTmec3d2FuXRGaa4tO9lIIgiAmNOTcEcQJZnK5B5v/8yL87s4lWDbZC5fNAq/bho3tPjzwxl6c/z/v4ovPbUHPcMRQlmlBWExNf+Q5oLrIqd8PAL9YeQCPvtuCYCyB7V0jWGUoKwRSnTsmDFnIij8UR4k2ML3UZYM/LEKWFYTjCdgsPCw8l1qWGU8NdSl0WnQB6rAk0zIB1elizt3MqgLs6R3Ve/yA1FEIA5qjxUJOWFlmo1cNYwlGE/CHVdHVWOZGfyCm9u+F45heWQAA6BuNYlR37hwpPXfsuuznK+dW44OWIV3sGRkKxtCgpYf6w3H4tXV2+sJ5x04kz5E8b7c/op/jaJy7hCTjle09ptdAEMeTLYf82N07iusX1p3spRAEQUx4SNwRxEnAbhFw7vRy8LyahnnDokn45+4+PPJOC8oL7Pjn7j5sbPfrASIOq4BQTIKiKFAUBS9v78HyqWW6eGJlmQDw1u4+7O0dBQAcHAjqvWhAqnPn0IQjc+B8obh+vmKXFZKsIBBNaIPKBbjtlqzizliWydbLnESv2w5ALSNla5xdW4RQXMJ2bSxEmceW5typTpyxLNMqcKguVoVsMCZiJCyi2GVFRYEd/YEogrEEErKCMzRx16/12BU6rSj32FN67oYNaZkcB9yytB4JWcFrOw9n/J6GgnGUeewodlrhD4t6SWUoniyvzMdQKIYyj/o69IxE9Od6NOLu3X0D+NIftmJTh/+Iz0EQx4KoKOE7L+xERYEdn5hfe7KXQxAEMeEhcUcQHwFuWVIPjgPOnFSMP9xzFv5wz1IAyVLNObVF8IXiWHNwEJs6/DjkC+PqeckBwU5DuMuB/iBe14SKogA7utSywGfXd+Anr6ujGuwWHlMq1GHlTCD4w3GUuFRxx0SeL6zOqHPZLPDYLQjEMssyWbklm3VnXA8rywQAt10Vgc01atnW2oNqcujkMs/YZZlBdV0F2vHBmIRhXdw5EBVlvQduaoUHPAf0j0YRiCb0nrtQXELfqCoaYwkZkbiEkYjq7M2pLcLkMndWcecLxeH12FDssmI4HNdLKgHVvctG/2g0JaBlMBjHjKoC2AQe3cMR3TkcOoqyTCZ8xyoP3dE1gst+/h5W/ORt/HNX5nMjiPGQkGRsOeTHe/sHMBIWsaNrBF/90zas+Mnb2NM7iu9/ohmFDmv+ExEEQRDHFeq5I4iPAPVeF574l0WYWV0IgeewsKEUL39xOXhO7fG6bmEt/u/tA7jvxZ0YiYgo89hx6ewq/fjaYifuXtGEc6eX4/YnN+A3a9rgsVsQjCWwtXMYCoD7XtypP57nOSyb7EWp24aXt/fgklmVKc5dCRN3oTgiYgJOmwCBy16WaRyFwGBpmSUuG5zaPD32uGmVHtgEHh9oYyEml7uxp3cUiqKA4zhd3PUFoognZAyF4vB67PA4NHEXTWA4Ekex04aKQtUR26/NnfN67Cjz2NE7EkUglkCh04LyAvUxLQNBfX3DkThGIqpA5DgOCxtKMkpYAdVd0+f+hUTwPPTXtdMf1scvGPnPl3bikC+C1+49B4Dq3DWVuVFd7EDPcFQv/xyPcyfJCoKxhC6gD2tCtWc4mvOYbzy/Hf5wHE6rgPtf24uIKGH1gUH8zw3zTF+XIAD1/7+7nt6U8m+E59Q+2+VTynDbWQ1YNsV7EldIEARBMMi5I4iPCBfMqNR76ABgbl2xHk5gtwj49hUzwQGYVuHBX/9tWYpTxvMc7rtqFs6dXo6LZlYAUEsrJ5e78eqHvfj6X7Zjcpk75XoWgccVc6qwck8fdnaPIpaQdVFXqjl4/lAcoZgqzIqcVvQHkoKEiTu3oSyTwfr5BJ7DJxeopVosBMYq8JhRrZZP2gQe8+uLEYglsPdwAFFRwmg0gUavC4qiDigfCqkCy6M7dyL8IRFFLqsu3PZp4q7EZUVloUMXcgUOq0HchfT1+UNq8iVb8+Ryj1rKaShhjSfUcQpejx3F2lB3X0jE3LoicBxwsD8pFo0c6AuidSCoJ5UOBePwum2oKXKi2x825dzd/9pefOG5LXqZ62OrWjDvv/6JbVopKwuR6RnOntopywpaB0P4xJm1uHR2Fbr8EbyyvRfPb+5C/2huQUgQ6YiSjB/8fTdW7R/ANy49A8/dvRTfuPQMfOH8qVj19fPxyK0LSNgRBEF8hCDnjiBOEa6eV5NSipmLn14/D5f+/D18+qwGNHjd+NffbwbHAX/9t7PRMxzBlo5h/bG3L2vEK9t7cfXDawAkRZ2xLDMSV8XdksZSPPzOQQwFY/B67PpMPdZfV12sDigvsFtwRlWBfo27VjTh2fWHdKECALctbcC/d32IuCTj/DNUMbpyT5/es7OgvgTtQ2Hs7wvAF4pjUolLF3eDwThaB4M4f0YFKgrUa+4/rIq7YpcNFQV2bGj3AQAKHRbUaIPTJVnRxzUw546JuynlqvD9+4e96PKH0VTmwYqpZQDU0tISlxU7u9UeveaaQkwp92Bn92jGay/JCjr9YXUcQzCGAocF4biEsgI7akucWHNgUE/cDMQSiIpSxrxESVbw2KoWAEBMlPCbf1mMt/f2AwDufnoj1vzHBXnF3eFR1fWs97ogK+oMxS2H1PLbdW0+XGPi/yMAeHdfP2qLnZhWWZD/wcQpx2hUxPObunD1vBo4rDwO9gcxo6oQkqLgxa3d6PSH8eauPrQOhnD7sgZ8/rwp4DgOZ2v/NgiCIIiPHiTuCOI0o9Rtw4ZvXwhOK+n8f1fNgkXgsKC+BAvqS3DV3OQX++mVBXjzK+di2f1vq+JHS8tkDt5AIIawmEBFgQOXNlfhobcP4q09fbhh4SQ94ZKVWy6b7MVr956D6ZUFuoABVFfssdsWYlZ1oX7bDYvqsObgICRZQUWhA/PqivC7Dzrw5Np2AMAls6vw1p4+/GNHL4aCarlogVaWuaHNB1FScOakYr0s0+jcVRQ69JENhU4rmsrcemlog9eFD7tGMBwWMRIRUVeiOqWs//C+F3fqg9Xn16sll163DSVum+64lbhtaK4pxPo2VUCKkgyrNquwZzgCUVKP7/SFUVno0M8RLnaiLxCFledRoPUvDoXiKPfYcfGDq3DXiibcvqwRe7QwnFK3DasPDEKUZBweicJh5TEYjGNH94jeP8hm/AFqEqpN4MFxnD63r6HUjYSs9m2yvsZ1rUOmxJ2iKPjSc1uxfGoZHvv0wryPB9S+rMdXt+KMSjUR9fqFk1CliWvio4U/FMfNv16HvYcDeOCNfYgmJCiKWuI9GhURiCZg4TnMrinEr29fhItnVZ7sJRMEQRAmIHFHEKchTNgBwJ1pw9TTqSh0YO1/XICH3zmApU2lAAC3TcD0Sg8efvsgIqKEK+e6Mau6EJNKnXhu/SG8ubsPb+1R3SQ29oDjOMw0CDgjlzVXpfzMcRweunm+/vNVc2vwo9f2gCX715U4cVlzFV7c2oO4JKPMY9MDWdYcHASghs8U2C1wWHl9bEKR04pKTfABah+gReAxu6YQmzr8qC9Vxd2e3lF0+yO4cIbqGtaXumDhOSRkBV84fwoicRlPrm0DoPbxFTmt+siIEs0dfHFbD/oDUdz0+DpUFznwy1sXpgxDP+QL6yK3zGOHrChQNBetubYQWw4NYzAQw4G+ADqGwnhpWw9uX9aIdVov4ufPm4If/H0PNrb50D0cwWfPnYzH32vFhjafLupYsMpoVMQ5P3kH37liJj61eBIO+dQS1AavS183g50/npDxfssgztOcU0AVzg+8sRf/+rEpmF5ZgEAsgd29mQ5lLja0+fDT1/fpP0dECUuavPjVqhZcO78WNyyaZOo8kqxgMBjTxXE2HnxzP2RFwdcuOcP0+k4GUVHCxnYfzplWnvX+DW0+TKvw6BsqJ4pfrDyAA/1B/OS6OdjSMYyqIgfqSpx4dv0hnFlfjHvOmYwzs/SUEgRBEB9tqOeOIAhUFTnwg0/MQbFWlslxHJ69+yzdvWr0usBxHL528RnY0T2Ct/b049zp5bh2fi14g0t3pNy1ognb/t8leOqOxVjaVIrJ5W58Yn4t4pIqTLweO6wCjwKHBb6QOp6gqsgBjuP00sxChwUWgcfChhL9vMztm1Wjis66EhdsAo9frWoFOOCO5Y0A1D7Aem2O3uXN1fjaJdP1c7BAFUaJy4rZWuLnE2va0DoQwtqDQ/jic1vQNpTs6zvkC+t9dV6PDYsaS/X7plWoZY7tQyG8oSVZbj3kR99oFG/sOoymMrcemPPHjZ0AVGd0WoUHb+/tR0SUUOaxIxBNIBAVsb7Vh5GIiFd39OrXtvAcqrUv7IwVU8vQOhBC/2gUz67vwB1PbUzp47v1N+uwsd2P//jrh/igZUg/l7EXcSyYg/rDa5tRXmDH2oNDuOfpTXi/ZQjPbThk6hwtA0Es/dFKLP3RSryXJeSGrfWRdw7iufWHoCgK/rypE9c/+n5K6mo6Xf6w3gd5InlqbTs+/cQGPfTHyGhUxM2/Xofvv7r7hK6p0xfGs+s78KlFk3Dj4nr85Pq5+MrF03HDokl48QvL8cgtC0jYEQRBnKKQuCMIIivlBXY8d89Z2Pv9y/B1zR35xPxaPHPXUvz8xjPxuzuX4MEbzzwm1+J5DkVOK86fUYE/fW4ZXDYLzp5ShqfuWIx7L5ymC51vXzETAFBfmhQsLH1ysSaezplWjuVT1YCHCi1MpcGr9tSNREQ8dPN8FDqt+NL5U1FX4tLPM6u6EE1lbsyuKYTbbtGDacoL7Ppwd0AVmrNrC2HhOTy1ph1um4DvXDETqw8M4kd/3wO7hUdVoQOdvgiGQjH9mCnlHn0o/ZKmUtQWO/Gtv+3AS9t60Kj1xl30s1XY2O7HbWc1oK7ECa+WZgoAM6oLsKixFJu10RULNOHdOxLFWs3NXN86hKgooWMojNoSJyyCOqyevQ43Llads3VtPqzUnNc1B1QBtaFdLXd94Pq58IfFFMGxtzdTmGRjf18AJS4rbllSj0tmVWJb5zDikozZNYXY1TOqj/YYiyfWtCEQFeGw8nqvYTq/fb8dCVnBUCiOnpEofrO6FZs6/Lj6/9bg3j9uRacvjHv/uFWfpdg3GsV5D7yL772yy9TzyMbuntEjGhr/7r7+lD+NbO7wQ5IVvLqjVx9un41wPIEDWcRhNswI2Aff2g+e43DvhdNMnZMgCII4dSBxRxDEmDisQkqZ5/KpZSdsWPH5MyrwlYun6wEvNy+px6O3LsBPrpurP2bFNDXc4cfXzdFv+92dS/HPr5yLCq2s72wtzW9ObREua67Cxu9ciC+lfbH9wSea8cfPnqU/18duW4iVX/sYChxWzKopRE2RA59aVIfzzihHocOK7149C3FJxsWzKnHXiiYsn+pFRAtIqfe6sKN7GP/c1QdAdf8A4NalDQBUwfi3z5+N88+owPz6YvzPDfNQUaCWfz5391LctaIJHMdhfr3qQpZ57KgqdOASQ98Te94Pvrkfq/YP6KWjf9vSjT29o6gvTQrXSVrZ6SWzK+GxW/DW7j6sb1OdOTZvcEuHHy6bgGvn1+Ky2VXqKAnN+dxyyI+oKOGt3X14am2bLqgBYCgYQ0Bz9vYeDmB6ZQE4jtOdH7dNwGfPnYx4QsaunpGM3/Hzm7tw62/W4b9f2Y3nN3fhxa3duHpeDZY2ebHm4CDiCRlfeHYL1hxQBWxCkvGXTZ1o1JzWLR1+dPoiaCpzo8xjw0vbevDtF1TR/PFH1mJ75zA+aBlCQlbwuw86sHJPn37tn725Xw+vGYtN7T5c8dBq/GZ1W97HMmRZgS8U18V4tlEbm9p94Di1RPZPmzqznufDrmFc+vP3cMnP38OrH/aMec3+QBQXP7gKX3xui947Cqhlrh92DeOV7T14Yk0bXtjajTvObqR+SIIgiNMQ6rkjCOKU4vI51Sk//88N8/DDT8xJ6VkSeA7TDQmPM6sLsf7bF+oOllGsMopdqT1PFoHHlHI1aKXB68b737ow5f5PL2tEvdeN5ppC8DyHp+5Ygt++34bqIic2d/jx2/fb0ToQwj3nNOmJmN+6Ygbm1xdjxdQy8DyHR25doJ/v9S+fC5dNSEnP/M6VM3FZcxWWTfGC4zicP6MCP71uLp5c24aPz6tFTJTxw3/sAQB87eLpePqD/9/evcdZVdZ7HP98ud/vl7gqAiGohIQmaplCitbRemlH047X6mhpWScr09fJo8fKrOxU3tOwl4Zd1KLUkEyyVGQm5KqA3C+CKAwyAjLMzO/8sRbjgHsPM8xlz+z9fb9e+8Xea55n7Wf9ZrPn+a3nWc9aw7cfWwjAxccfWrWfowZ1p7wyaN+mNRMO7Vk1GjhuSA/+taaEXWUVzF1bwgcG96BN61Zc8KGhPL5wIxOH96Z4dQnff3IJt85YWpUw3DFrBY9cfjzT52/gh08to0PbVjxwybEs21TK2R8cDLy7IM3xI/pw3GFJcj137TbatWnF/HVv0bNTW4pWl3D/c6sY0qsjxatL2F1eiQQXTjyEF1du5eYnXuGOWct5fOFGNm1/hxNH9uH5FVvYsqOM75x5BP/123lMm7OWXXsq+PqpozhxZB/G3zSTf7z6Jof27sTWHWXc/ewKunVoS7cObejaoS0Pzl7DpNH92fL2bu54ZjkVEQzv24UNJTt56uXX2bZzD8cP781Vk0ZWraa6NzH70cylTBrdj8PSz0Umyze/zfR5G/jzwo2sTG+/8YEhPShaVcK6rTsZUi3pLlpVwtjBPejWoQ13zlrBeccM2edzuGD9Ni68fw6d27Vh7KDuXP3wPFa9sYMvnTziPdOhy8oruWxqMeu27mLFGzvo1rEt3z5jNHNWbeHHM5fts7rr8L6dufyk4VmPwczMWi4dzDSTpjJhwoQoLi7OdTPMzOpkT0Ula7bsoFfn9lWjjo1l9Zs7eHnjdk4e1Y+3d5dTvHorI/p12ef2BWXllVRUBh3btWbanLVc++hCPnvcUM44agDn3/siJ47ow+yVW/jPkw7jmtMOT1bKnPYSpx85gD0Vlby6uZTKgP5d2zN2SA8unVqEgG279jB5dH9efb2U1eliMjd/6kgu+NAhVFYGlz/4L87/0FA+OqofH731Gba8XcaOsnKqzxy8aOIhXP+JMUByfV/Htq0Z2KMjSzZtZ8pP/gEk90Msq6jk5+cfzWNzNzBn1VaKrp/MOXc9X5W0zPn2JPp168A5dz5P8ZoSvjxpJHsqKrn77yuSKa+j+zO8X2fu+8cqiq6bzGMvbeDGP79Mz05tKdmZjDwe/r6u9O3anudXbKFrhzZ8ZGRfvvNvY/jcr4rZvmsPW3eU0TUdte3WsS1LN5WyYP02xgzoRtGaEpZuKmXtlp2UV1YybkgPRvbryubSd/jax0Zx7j0vsKeiku4d2zHp8H6U7Czjb0s2c/Hxh3LOhMGc8X//4OihPXl//y5s3r6bDdt2sWRTKX26tOeRKybSo1M7rv/DIv40/zUuPWEY35gyqupEwKo3dzBtzlrueXYld312PPPXv8Wds1bQrk0rysqTBYmuOW0U44b0pGuHNgxIr1c1M7OWQdK/ImJCrco6uTMzKxwRQXllVN2+4dcvruWG6YupiGDa54/j2GG9DrAHWLThLe5+diW791Rw27njWLNlJ1dNm5vcLP2qE/cZNd1r6aZS7vr7Cnp0asulJwxjy44y2rVuVbXYTSZPLtzItKJ1XDTxEL7067m8sye5Zu8LHzmMb58xmgdnr+HHM5dxSO9OPPbFEwD42dOv8qOZy3jkiokM6dWJj//0n7xRupvrPz6aicN78/Gf/pP2bVqxu7ySsYO7c++FEyhavZVDenXmqMHJQjkL1m9j6nOreXzhRvp368D6kp1cefIITj68HxfeN4fSavds3Htbi9atxPHDezOwe0eumTKKPl3a73Ms67bu5MHZa1i/bRczF7/OwB4dGD+0J1dPfj9De3fi4Y6CJFUAAA72SURBVDlrue2vy3hnTyWDenSkd5d2nDiiD+dWG82LCG6YvpgHXlhDm1ZizMBu9O/WgZkvJ1NNPz52ALefP56I4HtPLuGN0t2c88HBjB/as+p+lGZm1vI4uTMzs1orK68kSKZt1kdENNqI0PLNpWzY9g5DenZkWJ/OVe+z92/Y3tdv7drDjEWb+PSEwUii9J09TJ//Gp8cN4hO7Vpzw/TF7C6vpG/X9px2xPs4clD3rO/5rzUlXPO7+ax8cwePfvF4xg/tyc6ycha/tp2dZRUM692ZIb068pdFm+jZuV3V9NMDqayMjKvM7n8s2er+fdkbzFm9lblrSli++W3OHDeQyaP7c+ywXlVJu5mZ5Q8nd2ZmZg2gsjLYsG3XPtfKmZmZNaW6JHdNfopP0hRJSyUtl/Stpn5/MzOz2mrVSk7szMysxWjS5E5Sa+B24HRgDPAZSWOasg1mZmZmZmb5qKlH7o4FlkfEyogoAx4GzmriNpiZmZmZmeWdpk7uBgHV79S6Pt1WRdIXJBVLKn7jjffe9NXMzMzMzMzeq9ktqxUR90TEhIiY0Ldv31w3x8zMzMzMrEVo6uRuAzCk2uvB6TYzMzMzMzOrh6ZO7oqAkZKGSWoHnAdMb+I2mJmZmZmZ5Z02TflmEVEu6UpgBtAauD8iFjdlG8zMzMzMzPJRkyZ3ABHxBPBEU7+vmZmZmZlZPmt2C6qYmZmZmZlZ3Tm5MzMzMzMzywNO7szMzMzMzPKAkzszMzMzM7M8oIjIdRuyklQKLM11OzIYCqzNdSMKVHfgrVw3okA59rnl+OeOY587jn3uOPa55fjnTnPs54+KiK61Kdjkq2XW0dKImJDrRuxP0hvNsV2FQNI9EfGFXLejEDn2ueX4545jnzuOfe449rnl+OdOc+znSyqubVlPyzw423LdgAL2p1w3oIA59rnl+OeOY587jn3uOPa55fjnTovu5zf3aZnFzS1zhubbLjMzMzMzO3jNsZ9flzY195G7e3LdgCyaa7vMzMzMzOzgNcd+fq3b1KxH7szMzMzMzKx2mvvIneU5SVMkLZW0XNK30m33SZovaYGk30vqkqXutWm9pZJOq2mf9l5ZYi9JN0taJukVSV/OUvciSa+mj4uqbf+gpIXpPn8qSU11PC1JltifImmupEWSHpCUccErx75+JN0vabOkRdW23SppSfqd85ikHlnqZvxukTRM0ovp9t9IatcUx9LSZIn9DZI2SJqXPs7IUtexr4cssR8naXYa92JJx2ap6++cepA0RNIzkl6WtFjSV9Ltn05fV0rKOt3On32rs4jww4+cPIDWwArgMKAdMB8YA3SrVubHwLcy1B2Tlm8PDEv30zrbPnN9rM3tUUPsLwF+BbRKy/XLULcXsDL9t2f6vGf6sznAcYCAJ4HTc32sze1RQ+zXAe9Py9wIXObYN0r8PwKMBxZV23Yq0CZ9fgtwS21/b+nPfguclz6/C7gi18fZHB9ZYn8D8PUD1HPsGyf2T+39ngDOAGZlqOfvnPrHfgAwPn3eFViWfuePBkYBs4AJWer6s+9HnR8FP3KX5Qx6rc6GyCNH9XUssDwiVkZEGfAwcFZEbIdkFAnoCGSaO3wW8HBE7I6IVcDydH8Z99kEx9LSZIvTFcCNEVEJEBGbM9Q9DZgZEVsjogSYCUyRNIAkMZ8dEUGSJH6yKQ6mhckU+7OBsohYlpaZmW7bn2NfTxHxLLB1v21PRUR5+nI2MDhD1Yz/Z9LvqVOA36flHsCxzyhT7GvJsa+nLLEPoFv6vDvwWoaq/s6pp4jYGBFz0+elwCvAoIh4JSIOdC9nf/brqRD7+QWd3ElqDdwOnE5yFuUzksaQnLm9LSJGACXAZRnqjgHOA44ApgB3SGpdwz7tvQaRjFbstT7dhqRfApuAw4GfpdvOlHTjAepm3aftI1uchgPnplN0npQ0EkDSBEm/OEDdQenz/bfbvjLF731Am2pTc84BhoBjnwOXkoxCIGmgpCfS7dli3xvYVi05dOzr7kolU2Lvl9QTHPsmcjVwq6R1wA+Ba8HfOY1J0qHA0cCLNZTxZ7+BFGo/v6CTO7KPXtTmbIhHjhpRRFwCDCQ5w3Vuum16RPx3ThuW/9oD70Sy3O69wP0AEVEcEZ/LacvyW5D8EblN0hygFKgAx74pSboOKAceAoiI1yIi4zVg1mDuJDmpNA7YCPwIHPsmcgXw1YgYAnwVuA/8ndNYlKwf8Ahw9d4ZSpn4s9+gCrKfX+jJXbYzIhnPhnjkqMFtIB2dSA1OtwEQERW8O2WttnVr3KdVyRan9cCj6bbHgLF1qLuBfaezOfaZZYxfRLwQER+OiGOBZ0muy6hVXRz7epN0MfAJ4IJ0mtn+ssV+C9BD7y6A49jXQUS8HhEV6VTwe0k6Tvtz7BvHRbz7ff876hZ7f+fUgaS2JIndQxHx6IHKV+PPfv0UZD+/0JO7OvHIUYMrAkamc5/bkYxcTJc0AqquuTsTWJKh7nTgPEntJQ0DRpJc3J1xn01wLC1Ntjj9ATg5LXMSmROMGcCpknqmU6hOBWZExEZgu6Tj0t/dhcAfG/tAWqBsn/t+AJLaA98kuUB+f459I5A0BfgGcGZE7MxSLOPvLU0EnyGZSgtJh9mxr6X02q29PgUsylDMsW8cr5F8z0MykvFqhjL+zqmnND73Aa9ExI/rWN2f/SaUL/38Qk/usp0Rqc3ZEI8c1VN61uRKkj8er5Cs/PQK8ICkhcBCklWmboR9z6hExOK0/MvAX4AvpWd/37PPtKxVU0Ocvg+cncb/e8DnYN9rMCJiK3ATyR+dIpIFWPZeqP9F4Bck0xdWkF67ZO+qIfbXSHoFWAD8KSL+Bo59Q5M0DXgBGCVpvaTLgJ+TrGI3U8my8HelZauufTnAd8s3ga9JWk5yLcx9TXpQLUSW2P9AyXL6C0hOLH01LevYN6Assf888CNJ84HvAl9Iy/o7p2GdAPwHcIqq3fJD0qckrQcmAo9LmgH+7DewguznF/RNzNNf7DJgEskvpgg4n2Rp5kci4uH0j/yCiLhjv7pHAL8mmcYwEHiaZPRImfbpBMPMzMzMrGkUaj+/oEfuajgjkvFsiEeOzMzMzMyav0Lt5xf0yJ2ZmZmZmVm+KOiROzMzMzMzs3zh5M7MzMzMzCwPFFxyJ+l+SZslLaq27VZJSyQtkPSYpB5Z6k6VtErSfEnLJP1K0uBMZc3MzMzMrOlk6efflPbx50l6StLALHVnSVqall0i6efZcoLmrOCSO2AqMGW/bTOBIyNiLMkKONfWUP+aiPgAMAp4Cfhbeu8RMzMzMzPLnam8t59/a0SMjYhxwJ+Bmu5ld0GaD4wFdtMC7x9YcMldRDwLbN1v21PV7lQ/m+SeFQfaT0TEbcAm4HQASadKekHSXEm/k9Ql3X6MpOfTEb85kro26EGZmZmZmRW4LP387dVedgYOuJpkRJQB3wCGSvoAgKTPpv34eZLultQ63T4l7fvPl/R0gx3MQSq45K4WLqVuN+KcCxwuqQ9wPTA5IsYDxSTLrLYDfgN8JR3xmwzsauA2m5mZmZlZBpJulrQOuICaR+6qREQFMJ+knz8aOBc4IR0BrAAukNQXuBc4O+3nf7pRDqAOnNxVI+k6oBx4qC7V0n+PA8YAz0maB1wEHEIyfXNjRBRBcvag2iihmZmZmZk1ooi4LiKGkPTxr6xD1b39/EnAB4GitJ8/CTiMpP//bESsSt9na8a9NCEndylJFwOfIJlrG+m2X6ZDr0/UUPVokpsYCpgZEePSx5iIuKzRG25mZmZmZrXxEHA2gKQZaT//F5kKptMuj+Ldfv4D1fr5oyLihqZqdF20yXUDmgNJU0jm1Z4UETv3bo+IS2qoI+AqYADJneu7A7dLGhERyyV1BgYBS4EBko6JiKL0ertdHr0zMzMzM2tckkZGxKvpy7OAJQARcVoNddoCNwPrImKBpHLgj5Jui4jNknoBXUnW6rhD0rCIWCWpV65H75QOUhUMSdOAjwJ9gNeB75Csjtke2JIWmx0Rl2eoOxU4CdgOdCL5hV4bEevTn58C3JLuC+D6iJgu6RjgZ0BHkuvtJkfE241xfGZmZmZmhShLP/8MksukKoE1wOURsSFD3Vkkgza7SfryfwWui4ht6c/PJckZWgF7gC9FxGxJpwPfTbdvjoiPNeIhHlDBJXdmZmZmZmb5yNfcmZmZmZmZ5QEnd2ZmZmZmZnnAyZ2ZmZmZmVkecHJnZmZmZmaWB5zcmZmZmZmZ5QEnd2ZmZmZmZnnAyZ2ZmeUVSVdL6nQQ9S6WNLAu+5b0hKQeB9NOMzOzhub73JmZWV6RtBqYEBFv1qFOa+Bp4OsRUdyQ+zYzM2sqHrkzM7MWS1JnSY9Lmi9pkaTvAAOBZyQ9k5a5U1KxpMWS/qda3dWSbpE0F/gMMAF4SNI8SR0zvNeXM+x7taQ+kg6VtETSVEnLJD0kabKk5yS9KunYau29X9IcSS9JOqvRg2RmZgXDI3dmZtZiSTobmBIRn09fdwfmU210TVKviNhabXTuyxGxIB2FuyMifpCWm0UdR+72vga6AMuBo4HFQFHajsuAM4FLIuKTkr4LvBwRD6bTOecAR0fEjgYMi5mZFSiP3JmZWUu2EPhYOgL34Yh4K0OZf09H514CjgDGVPvZbxqwLasiYmFEVJIkeE9HcgZ1IXBoWuZU4FuS5gGzgA7A0AZsg5mZFbA2uW6AmZnZwYqIZZLGA2cA/yvp6eo/lzQM+DpwTESUSJpKklDt1ZAjZrurPa+s9rqSd//eCjg7IpY24PuamZkBHrkzM7MWLF3dcmdEPAjcCowHSoGuaZFuJAncW5L6A6fXsLvq9epTpiYzgKskCUDS0fXYl5mZ2T48cmdmZi3ZUcCtkiqBPcAVwETgL5Jei4iTJb0ELAHWAc/VsK+pwF2SdgETI2JXhjL3VN/3QbT3JuAnwAJJrYBVwCcOYj9mZmbv4QVVzMzMzMzM8oCnZZqZmZmZmeUBT8s0MzPbj6THgGH7bf5mRMzIRXvMzMxqw9MyzczMzMzM8oCnZZqZmZmZmeUBJ3dmZmZmZmZ5wMmdmZmZmZlZHnByZ2ZmZmZmlgec3JmZmZmZmeWB/wf4BAZtO8TInQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 1080x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_jam_w_time.groupby(['start_time']).size().loc[datetime(2017,12,12,0,0,0):datetime(2017,12,13,0,0,0)].plot(figsize=(15, 6))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### You can see the rush hours are around 2am and 4pm. The rush hour at 2am doesn't make any sense. But by converting them to local PST(subtract hours): 6pm and 8am, this makes perfect sense."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 675,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime\n",
+    "from pytz import timezone\n",
+    "import pytz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 676,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time['start_time'] = pd.to_datetime(df_jam_w_time['start_time'])\n",
+    "df_jam_w_time['end_time'] = pd.to_datetime(df_jam_w_time['end_time'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add time zone info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 677,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time['start_time'] = df_jam_w_time['start_time'].apply(timezone('UTC').localize)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 678,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time['end_time'] = df_jam_w_time['end_time'].apply(timezone('UTC').localize)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 679,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 6543827 entries, 0 to 6543826\n",
+      "Data columns (total 9 columns):\n",
+      "jam_id         int64\n",
+      "datafile_id    int64\n",
+      "street         object\n",
+      "road_type      int64\n",
+      "delay          int64\n",
+      "length         int64\n",
+      "line           object\n",
+      "start_time     datetime64[ns, UTC]\n",
+      "end_time       datetime64[ns, UTC]\n",
+      "dtypes: datetime64[ns, UTC](2), int64(5), object(2)\n",
+      "memory usage: 499.3+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_jam_w_time.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 680,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time.rename({'start_time':'start_time_utc', 'end_time':'end_time_utc'}, axis='columns', inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Adding PST timezone"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 681,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time['start_time_pst'] = df_jam_w_time['start_time_utc'].apply(lambda x: x.astimezone(timezone('US/Pacific')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 682,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_w_time['end_time_pst'] = df_jam_w_time['end_time_utc'].apply(lambda x: x.astimezone(timezone('US/Pacific')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 683,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'pandas.core.frame.DataFrame'>\n",
+      "Int64Index: 6543827 entries, 0 to 6543826\n",
+      "Data columns (total 11 columns):\n",
+      "jam_id            int64\n",
+      "datafile_id       int64\n",
+      "street            object\n",
+      "road_type         int64\n",
+      "delay             int64\n",
+      "length            int64\n",
+      "line              object\n",
+      "start_time_utc    datetime64[ns, UTC]\n",
+      "end_time_utc      datetime64[ns, UTC]\n",
+      "start_time_pst    datetime64[ns, US/Pacific]\n",
+      "end_time_pst      datetime64[ns, US/Pacific]\n",
+      "dtypes: datetime64[ns, US/Pacific](2), datetime64[ns, UTC](2), int64(5), object(2)\n",
+      "memory usage: 599.1+ MB\n"
+     ]
+    }
+   ],
+   "source": [
+    "df_jam_w_time.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 684,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA3cAAAFsCAYAAABvvUBnAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJzs3Xd4ZHd9L/7390wv6mWLtq933Q1er40XQontGENIDL9AAvxuIMSJb0jjkuQmTiU/8iM3IYVUICaY2IFgygPBAQI2phn3XXevy/ZdSateps+c8r1/nDJnpJF0zmik0cy8X8/jZ6UzZ6SztjQ+n/k0IaUEERERERERNTel0RdAREREREREq8fgjoiIiIiIqAUwuCMiIiIiImoBDO6IiIiIiIhaAIM7IiIiIiKiFsDgjoiIiIiIqAUwuCMiIiIiImoBDO6IiIiIiIhaAIM7IiIiIiKiFhBs9AUsp7+/X+7atavRl0FERERERNQQR44cmZJSDng5d0MHd7t27cLhw4cbfRlEREREREQNIYQ44/VclmUSERERERG1AAZ3RERERERELYDBHRERERERUQtgcEdERERERNQCGNwRERERERG1AAZ3RERERERELYDBHRERERERUQtgcEdERERERNQCGNwRERERERG1AAZ3RERERERELYDBHREREVGbkVLi/hfGoelGoy+FiOqIwR0RERFRm/nOCxO45c7D+NQDpxp9KURURwzuiIiIiJrUTLYEtYbs26mpDABgKlOs9yURUQMxuCMiIiJqQoYhcf3ffB//8ehZ389N5TUAQGc0VO/LIqIGYnBHRERE1ISKmoHZnIqxVMH3czNFM7jriAbrfVlE1EAM7oiIiIiaUFHTAQAFVff93FRBBQAEA6Ku10REjcXgjoiIiKgJFTWz166g+u+5s8sySxqnZRK1EgZ3RERERE2oaAV1xRoyd2krc1dkcEfUUhjcERERETUhuyzTa4CWLqj46pPDkFIiVTAzd7VM2iSijYtdtERERERNqFyW6S1zd+dDp/HX974MKYHZbAkAyzKJWg0zd0RERERNyBmoonkL7uJh8z39rzwxgumsud+OmTui1rJicCeEuEMIMSGEeK7KY78thJBCiH7rcyGE+AchxHEhxDNCiAOuc98rhDhm/fPe+v41iIiIiNqL3XPnd6DKj45PQdUlAGbuiFqNl8zdvwG4aeFBIcR2ADcCcG/OfBOAfdY/twL4hHVuL4APAXgVgGsAfEgI0bOaCyciIiJqZwWn585b5q5ab16JmTuilrJicCel/CGAmSoPfQzA7wKQrmM3A7hLmh4B0C2E2ALgjQDuk1LOSClnAdyHKgEjEREREXnjN3NnZ+l+4pJNrmNyqdOJqAnV1HMnhLgZwIiU8ukFDw0BOOf6fNg6ttTxal/7ViHEYSHE4cnJyVouj4iIiKjl+R2oUtR0BBWBf373AXz8/z2A7b0xZu6IWozv4E4IEQfwBwD+pP6XA0gpb5dSHpRSHhwYGFiLb0FERETU9JyBKj4yd5GggnBQwZsv34JYKACVPXdELaWWzN1eALsBPC2EOA1gG4AnhBCbAYwA2O46d5t1bKnjRERERFQDO3Pnp+cuEgo4n4eDCjN3RC3Gd3AnpXxWSjkopdwlpdwFs8TygJRyDMA9AN5jTc28FsC8lPI8gG8DuFEI0WMNUrnROkZERERENbB77ooeM3dFTUc4UL71CwcUTsskajFeViF8HsDDAC4UQgwLIW5Z5vRvAjgJ4DiATwH4VQCQUs4A+DMAj1v/fNg6RkREREQ1sDN2Jd2Abqw8GKWkGYiEyrd+oQAzd0StJrjSCVLKd63w+C7XxxLAry1x3h0A7vB5fURERERUhXu1QVHTnSXly50fCboyd0EF6YK2ZtdHROuvpmmZRERERNRYFcGdh9LMomYgHKwsy1SZuSNqKQzuiIiIiJqQewVCwcNQFXNa5oKBKuy5I2opDO6IiIiImpA7W+dlHUJR0xeVZbLnjqi1MLgjIiIiakLuFQj/cP8xfP+liYrHpzNFvDyedj4vLSjLDAUU7rkjajEM7oiIiIiakLvn7qtPjuBrT41WPP4P9x/D+z7zeMX5zNwRtTYGd0RERERNqLgg65YrVU6+nMwUMZsrVZwfdvfccc8dUcthcEdERETUhIqaDkWUP8+VKoeqpPIaciUdhrUDr8TMHVHLY3BHRERE1ISKqoHOWMj5PFuszNylCioAIG9N1Vw0UIWZO6KWw+COiIiIqAkVNQNdruBucebODO6yVrlmUV08UMWQgG5l9oio+TG4IyIiImpCBVVfNrhLF8ygLle0Mnf64j13AJi9I2ohDO6IiIiImtDizF25LFNK6ZRlZksapJSLeu5CAbNhj313RK2DwR0RERFREypqOjqj1TN3BdWAqpvllvmS7gRw7rLMCDN3RC2HwR0RERFREypqBrrilcGdPRnTztoBQLakO2sTIgt67gBm7ohaCYM7IiIioiZUVA0kI8GKY/ZkTHuYCgDkihqKqhXchRb33KnM3BG1DAZ3RERERE1GSrlotQFQLs1MFcr9d1lXWWYkULnnDlg+c/fRb72IX77rcN2um4jWFoM7IiIioiajGRKGNMssH7rtOvz/b70MQHmoirssM1fSULQyepFQlbLMZTJ3h8/M4okzs3W/fiJaG8GVTyEiIiKijcTuoQsHFWztjqE/GQYAZIuLyzKfHZ7Hk2fnAFT23HnJ3I2nCpjJlaDpBoIB5gSINjoGd0RERERNpmBl4qJWD108bN7S5VU7c1cuy/zSkWHnY/e0zPAKmTspJcZTBUgJzORKGOyI1vFvQERrgW/BEBERETUZJ7gL2sGd+efCzF14Qbat2hJzdYnMXSqvoWANYplKl+p16US0hhjcERERETWZgjP90ryVszN37p67cFBBt2tVArCgLHOFzN1YquB8PJUp1unKiWgtMbgjIiIiajKLyzLNP+1pmemChs5oEIkFqxLCVfbcLZW5G3cFd9NZBndEzYA9d0RERERNpqgtCO4i5p+nprKYTBcxPl9Adzy8aFVCtbLMopfMHcsyiZoCgzsiIiKiJmOXZUatAC1hlWX+43eP476j4zg7k8PbrhzCsfFMxfPcwZ6d7XMPX3EbnzeDu6AiWJZJ1CQY3BERERE1mYVlmbFQOSP34lgaAHDDJZswPJuveJ67LHNLVxRdsRCOjs5X/R7j6QK64yHEQwFMMrgjagrsuSMiIiJqMk7mzgrqFEVUPB4PB3BoTx8SVrlmwsrSuYM7IQSu2NaFZ4aXCO5SRWzujKK/I4KpDMsyiZoBM3dERERETaacuVv8Pv0Hb9iPSEhBNBRwpmh+4X8ewnxeRX8yUnHu5UNduP2HJ1FQdSdQtM3nVHTHQ4iFAvjeS5O4+7GzeOc1O9bob0RE9cDMHREREVGTyS8oy3T7wA378Cuv3wugnLHb3Z/Aay7oX3TuFdu6oRkSL5xPLXosU9SQjASxsy8BALjtK8/W7fqJaG0wuCMiIiJqMguXmAPAq/f24W1XDlWcd/m2bhzc2bNoJUL58S4AwHOji4O7bElDPBzE/37jhXjHVdsAlKd0EtHGtGJwJ4S4QwgxIYR4znXsr4QQLwohnhFCfFUI0e167PeFEMeFEC8JId7oOn6Tdey4EOK2+v9ViIiIiNqDvb4g4irL/I9fvhYf+7lXVpz39qu24cvvf/WSX2dLZxShgMDwbG7RY9mihkTE3JV32ZAZBGaWmKxJRBuDl8zdvwG4acGx+wBcJqW8AsDLAH4fAIQQlwB4J4BLred8XAgREEIEAPwzgDcBuATAu6xziYiIiMingqpDCCzaY+eXoghs7opibL6w6DGzLNPMDCatzF+myOCOaCNb8RVBSvlDADMLjt0rpbR/ux8BsM36+GYAd0spi1LKUwCOA7jG+ue4lPKklLIE4G7rXCIiIiLyqaDqiAQVCCFWPnkFW7piOD9XGdzphkRBNZxyzmSUwR1RM6hHz90vAvhv6+MhAOdcjw1bx5Y6vogQ4lYhxGEhxOHJyck6XB4RERFRaymoRtVhKrXY2hXF6HzlPrxsyQzi7Ixdh525Y1km0Ya2quBOCPGHADQAn6vP5QBSytullAellAcHBgbq9WWJiIiIWkZB1SuGqazG5q4YxlMFGIZ0jmWtDB0zd0TNpeY9d0KIXwDwFgDXSyntV4MRANtdp22zjmGZ40RERETkQ0Ezqu64q8XW7ihUXWIqW8RgRxTA4uAuwZ47oqZQ06uCEOImAL8L4KellO7xSvcAeKcQIiKE2A1gH4DHADwOYJ8QYrcQIgxz6Mo9q7t0IiIiovZUbel4rbZ0xQCgou8uUzRXHtgDVeyyzDTLMok2NC+rED4P4GEAFwohhoUQtwD4JwAdAO4TQjwlhPgkAEgpnwfwRQBHAXwLwK9JKXVr+MqvA/g2gBcAfNE6l4iIiIh8Kqg6InUL7sxs3XlX352TuQuzLJOomaxYlimlfFeVw59e5vyPAPhIlePfBPBNX1dHRERERIsUVQPRVa5BsG3tNjN3L49n8Mzwi7hmd6+zR88ux4yFAlBEOegjoo2p5p47IiIiImqMgqajJx6uy9fqiYdwYEc3/va+lwEA33z2PH7jun0AysGdEALJSJBlmUQbXH3e8iEiIiKidWP23NXnNk4IgTt+4Wq8bv8Arr9oEKenc7j36BgAIBEpl34mI0GWZRJtcMzcERERETWZeu65A4DueBh3/eI1KGo6rv3z+/Ht58cBlPfcAWbfHffcEW1szNwRERERNZl67rlziwQDOLCjBwCgCLPXzsbMHdHGx+COiIiIqMnUsyxzoX2bOgCYgZ4QwjmejIaQZnBHtKExuCMiIiJqMuYS8/pn7gBg/6YkACCv6hXHOyJBT9Myf3RsCmPzhRXPI6L6Y3BHRERE1EQMQ6KkGXXbc7fQfitzt1AyUtlzly6o+IOvPltRqjk8m8P/+PSjuO0rz6zJtRHR8hjcERERETURewfdWpVl7h1IVj2eWNBzd/j0LP7j0bN44sysc+zzj50FAIQCvMUkagT+5hERERE1kYJVLrkWA1UAIBau/nU7omZwp+lmcJkqqADKi80NQ+ILjw8DAHrrtIOPiPzhKgQiIiKiJlLQrOBujcoyAeD2n79qUZA31BMDAIzM5bGzL+EsNLeHrORUHVOZYsU1EtH6YnBHRERE1EReGksDALb3xtbse9x46eZFx3b3JwAAJ6eyFcGd3YeXK5VLNouqsWbXRkRLY1kmERERURN56MQ0wgEFB3f2ruv3tYO701NZAOZAFaBcllkolQM6Zu6IGoPBHREREVETefD4FA7s7F6yN26t9CXC6IgGccoJ7qzMnVOWycwdUaMxuCMiIiJqEnO5Eo6eT+HVe/vX/XsLIbC7P+EEd/ZAFafnrlTO1jFzR9QYDO6IiIiImsSZ6RykBC7Z0tmQ77+7P4GTk5WZO7ssM28Fd12xEArM3BE1BIM7IiIioiZhB1SdsVBDvv/u/gRG5/MoqLrTc2cPVLGDu554CEVm7ogagsEdEZEPDx2fQknjO9JE1BiZohlQJSONGXi+uz8BKYGzM7mqqxAAoDseZs8dUYMwuCMi8uj4RAbv/tdHce/RsUZfChG1qZQVUHVEGxfcAcDJyWyVskzzz95EmJk7ogZhcEdEVIVhSMzlShXHTkxmAADTmVK1pxARrblMg4O7XfY6hOmsM1Als6DnrjvOnjuiRmFwR0RUxecfP4tXfvg+PDcy7+x0OjudAwCk8mojL42I2pidLWtUWWZnNIT+ZBgnJjJOUOcsMVftnrswCiozd0SN0JhXBiKiDe7I6VkAwP/z8YdQ0g18+VcO4cxM5fhvIqL1limqiIcDCAYa9/787v4Enh2Zh5RAUBEVmTshzGmZmiGh6UZDr5OoHfE3joioirz1rvNARwSJcAB3PXwGZ5zMnbbcU4mI1ky6oDUsa2fb3Z/Ai2NpAMCmziiKmoGSZiBX0hEPBRANmbeXRQ6fIlp3DO6IiKoYncvjdfsH8OBt1+EdB7fjv587jyfPzgFg5o6IGidd1BrWb2ez++4AYGt3FIA5VCWv6oiFg4gEAwAY3BE1AoM7IqIqRuYKGLJuWt5zaCdUXTqlRwzuiKhR0gUNyWhjdtzZXrW7z/l4S1cMgDlUJV/SEQsrTuaOfXdE64/BHRHRAgVVx1SmiK3WTcuegSRetbvXeTyV13B6Kst9d0RUV1LKFc9JF1R0Njhzd9XOHvQmwgCAzV3mm2CZooZcSUM8VM7cMbgjWn8M7oiIFhibLwAAtnbHnGN/+3OvxLV7enFgRzfGUgW84a+/jw/c/WSjLpGIWswb/up7uO5vfrDk44Yhcfj0DDIboOcOAL75m6/FL75mt/PGV6aoIa8aiIXZc0fUSAzuiIgWGJ3LA6gM7oa6Y7j71kO4dGsXJtNFAMB/P8dl5kRUH6enczhlrV2p5ktHzuHtn3wYxyYyDe+5A8yM3Z/81CXoS0YAAJPpIvIlDfFwAJEQM3dEjcLgjohogREruBtyBXe2zliw6rlERGtpOltyPk5GGttz53bxlg4MdkTwuUfPIFfSEQsFEAnaPXfM3BGttxWDOyHEHUKICSHEc65jvUKI+4QQx6w/e6zjQgjxD0KI40KIZ4QQB1zPea91/jEhxHvX5q9DRLR6o3MFCAFs6ooseqxzwSCD7744sV6XRURtQNOrB0Q98bDz8UbI3NkiwQB++bV78ODxaTw/mrLKMu1pmczcEa03L5m7fwNw04JjtwG4X0q5D8D91ucA8CYA+6x/bgXwCcAMBgF8CMCrAFwD4EN2QEhEtNGMzuUxkIw4QwHcOmNmcBdUBDqjQbx4PrXel0dELWzGlaFzy5fKgdJGCu4A4Gev3u58HA8zc0fUSCsGd1LKHwKYWXD4ZgB3Wh/fCeCtruN3SdMjALqFEFsAvBHAfVLKGSnlLID7sDhgJCLaEEbn8xX9dm525m5zVxRDPXFn+AoRUT1MZopVj+fVjRvcdcVC2DNg7r6Lh4PM3BE1UK09d5uklOetj8cAbLI+HgJwznXesHVsqeOLCCFuFUIcFkIcnpycrPHyiIhqNzKXr9pvB5R77oa6Y9jSFcV5BndEZPnWc+fx+195dlVfwx7YtFCupDkfq/rKKxPW2xVDXQCAaMhVlsnMHdG6W/VAFWkuZanbq4yU8nYp5UEp5cGBgYF6fVkiIk+klBidy2OrtcB8ITtzN9RjBndjKQZ3RGT6lc8+gc8/dnZVX2Pp4K6cBYuFFpeMN9qlW83gLlNUy2WZzNwRrbtag7txq9wS1p/2RIERANtd522zji11nIhoQ5nNqSioxtJlmVbPnZ25m8mWOO6biCoYRu3veS9ZllnSMdARwb++5yDedmXV4qeGumBTEgBwbDzDzB1RA9Ua3N0DwJ54+V4AX3Mdf481NfNaAPNW+ea3AdwohOixBqncaB0jItpQqu24cxvsiKAnHsIrt3djc5d5DvvuiMgtW9IgpfT8xo9ZBGWaSlcfqJIr6UiEA7jhkk1QFFGX66yna3f34fKhLvzuTRe6BqrwjS+i9eZlFcLnATwM4EIhxLAQ4hYAfwHgJ4QQxwDcYH0OAN8EcBLAcQCfAvCrACClnAHwZwAet/75sHWMiGhDsffWbe2qHtwlIkE8+Sc34vqLN2FLl1m6yb47InLLlXR86oGTuOiPv4XZJaZfupVc6w+WytzlSjpi4Y01SMUtFg7gv37jx3DVzl6EAgoCikBRY+aOaL2t+CohpXzXEg9dX+VcCeDXlvg6dwC4w9fVERGts3LmrnrPnZsd3I2luMiciMoyRQ13PnQGADCfV9GTCC97fskVBE2mq79ZlFc1xMMbr9duKdGgwswdUQOseqAKEVErOTOdQzSkoHeFmzHAXIcAMHNHRKagVS6ZLWqYz6sAAOGhgtId3C215y5X0psquIuEAhXrG4hofTC4IyJyeeTkNA7s6IHwcEcWDwfRFQvh/ByDOyKCM0gkU9SQKZqrC7ysLXCfk8prVc/Jl/QNOSVzKVu6ojg3y6oGovXG4I6IyDKRKuDFsTReu8/7GpbBjgimluiRIaL2Yg8SyRbLGSvNWLnvzM7c9SbCTsZvoWbL3O3f1IFj4+lGXwZR22FwR0RkeeDYFADgtfv6PT+nPxlZci8VEbWXcnBXzr5pHjJ3Jd0MBgeSEeRVvaJM07bRB6ostG9TEufnC0gVqgerRLQ2GNwREVkeOTmNnngIl2zp9PycgY7IktPtiKi9RFxlmTZVXzlzZ0+V7O8we32rBUT5UnMNVNk/2AEAzN4RrTMGd0RElpNTWezf1OFrh9RARwRTzNwREcqZu+lMeSiK5mGhuZ2p609GAGBRaaaUEjm1ucoyL9xsBncvj2cafCVE7YXBHRGR5cx0Frv6Er6e05+MIFvSK8qwiKg9ha3g7sxM1jmmetj1Zg9UsYO71ILgrqgZkNLcJdcshrpjiIUCeGmMmTui9cTgjogIQLqgYipTwq5+f8HdQId5M8ahKkSkW1m6M9M555jqI3Nnv54szNzlSmZPXryJpmUqisDOvjhG5jgxk2g9MbgjIgJwesq8GdvdH/f1PAZ3RGSzh6ecmc66jnmYlukaqAJUBndHR1P45bsOAzDXrzSTnngYc7nqe/uIaG0wuCMiAnDauhnb6bss0xyAwImZRGSvPZhy9dx52XPn9NxZbxalCuUy7z/7+lEcOTMLoLnKMgGgJxFacik7Ea0NBndERABOT5nBnd+eOztz5zW4yxQ1/Obnn8Q0M31ELafa8BQve+6caZnWm0Xunjs74APQVANVADtzx1UIROuJwR0REYCj51PY3Bn1/c54XyICRQCTGW/vTr9wPoV7nh7Fk2fnarlMItrA3Dvt7MmZXvbc2dm9jkgIkaBSUZYZdE3vbbbMXW8ijNlcCYaHvkMiqg8Gd0TU9r730gT++7kxvOWKLb6fG1AEehNhTKYLns63J+eVPPTh1MPoXN7JShLR2nJn6V6xrRuAt991uywzHFTQFQtVZO7c/bzN1nPXHQ/DkNX39gHmiocJj6+dROQNgzsianuf+uFJ7OyL43feeGFNzx/qjuHcjLeJcEXrRq+o6TV9L78+8o0X8DtfenpdvhdRu3Nn6a7Y1rXo2FJK1utBOKigMxaqyNy5e9a8b+DcGHoTIQDA7BKlmb/75WdwzUfuZ88yUR0xuCOitjeRLuKSLZ2I1jhmfO9AEscnvC3qtd+hL3nYfVUP6aKGbGl9AkmidufuubvcDu489NzZ2T07c+cO7qYzJbzhwgHc+ro9uHRrZ52veG11x80ewmpDVZ46N4cvHRkGUDldlIhWh8EdEbW96UzRWR5ci72DSYylCsh4WGSuOpm79QnuDEOy34VonbjXHlxhlWX6mZYZDlhlmVYZo5QS09kiLt7SiT9488UIBprrtq3XCu6qrUN45OS08/H5eZZmEtVLcxVvExHVmaobmM2p6LOm1NXigsEkAODERAav2N697LnrnbnTDAOGZHBHtB40Q+LVe/twze5eDFpTLr3tuTN/R0MBgU2dERw+PYP5vIpj42moukRfovbXp0bqWSZzl3NVFJyf56JzonpprreAiIjqbNa66ehbRebODu68lGbaQd36Ze4AncEd0brQDIkrd3Tjf92wH8GAcI6tpKQZCAcUCCHw2n0DSBU0vOOTD+Htn3wYAFZVWdBIPU7P3eLgrqDqiIUCSEaCGJ1j5o6oXhjcEVFbs5cN96/infEdvXGEAgLHJz0EdzWUZeZLOs7N5Gq6Ns0wWJZJtA6klNANiaBi3lqFrD9Vj9Myw9bqhNftH0A4oODl8fLryWoqCxopGQkiFBCYTBcXZTBzJQ2xcABbuqLM3BHVEYM7Impr01lzSttqMnehgIJdfQm8cD614rnlzJ33ISe/8tkjeO1HvwdZQwZOlwBjO6K1Z2foQlbGTlEEAorwFtzpuhPcJSNBvGpPL4RrNGZfojkzd0IIREMBfOqBU/iluw5XPJYvGYiFAtjSHWPPHVEdMbgjorY2bWfuVvnO+Ov3D+Ch49NL7nOy2Zk7Pz13P3h5EgA8DWxZSDcM6IzuiNacvfIgoJRvrYKK8LgKwSzLtP3eTRfhr9/+CufzZs3cAUC6YL5uPXh8CrlS+TUsr1qZu84oyzKJ6ojBHRG1NXtB8GoydwDwk1dsQUk3cN/z48ueV0vPXSJsrmhwj0f3SjfAgSpE68BeeWBn7syPFU/TMlVdIhQsP++yoS78zFXb8Hs3XQQA6G3SgSoA8FdvvwLvvHo7VF3isVMzzvF8SUc8HMCW7iimMsV1GzJF1OoY3BFRW5vKlBAKCHRGVzc8+JXbuzHUHcN/Pze27Hm1TMuMhc1rqy24Y+aOaD2UM3flIC0YEN723C3I3Nne/4a9OPV/3oxQk61AcHvHwe340E9dinBAwcMnyusPciUd0VAAW7tiAIDxFLN3RPXQvK8WRER1MJ0poi8RgXA3uNRACIGrd/Xg6Oj8sufVsucubmfucrUEd5I9d0TrwO65c++iCyreMndFzUA4GKj62GpfmzaCWDiAV+7oxiPuzJ1qZu7sktNq6xKIyD8Gd0TU1qazpbr1s1wwmMTofAHZZXrjypk77wNV4qsoyzQkyzKJ1oNTlqm4yzKFxz135WmZrWrvQBIjs+Wpv/lSeRUCUFtPMREt1tqvJEREK5hIF+q2Q8pZZr7MSoRaBqqsJrjTWJZJtC6qlWWaPXdeyjJ1RJq49NKLTZ0RTGVKzr+PXElHLBxAgsEdUV219isJEdEypJQ4M53Djt54Xb6el+CuWMNAlfgqeu4MDlQhWhflVQiussyAgOrhzZWFA1Va0abOKABgMm0OsbKXmHdY/c6ZAoM7onpYVXAnhPigEOJ5IcRzQojPCyGiQojdQohHhRDHhRBfEEKErXMj1ufHrcd31eMvQERUq7mcinRBw86++gR3O/sSCCoCxyeWDu7s/hs/mbugNX1vrsbMHZeYE609u/yyInOnKCuWZT52agZHzsxWHajSSjZ1mhUSE1Zwl7OmZbIsk6i+an4lEUIMAfhNAAellJcBCAB4J4C/BPAxKeUFAGYB3GI95RYAs9ZGYWb/AAAgAElEQVTxj1nnERE1zOnpLAAzKKuHUEDBzr74ssGd3WvnJ3Nnl3vVugpBZ+aOaM0tXGIOWNMylxmoohsSt9z5OACgt0kXlXs12GFm7sZTBUgpkVd1xMJBJKMM7ojqabVvEwUBxIQQQQBxAOcBXAfgy9bjdwJ4q/XxzdbnsB6/XrTCCCgialpnps3m/l11ytwBwP5NHTh6PrXk47WsQrD79GpdheBhEjsRrVLVJeYBZdmyzKOjKaQLGm5700X405++ZM2vsZEG7cxdqoCCar4oxUIBRIIBhAKCwR1RndQc3EkpRwD8NYCzMIO6eQBHAMxJKe3f0GEAQ9bHQwDOWc/VrPP7av3+RESrdWY6ByGA7XXquQOAa3b34txMHudmclUfLzmrELxPy7QHEKRqCu4ke+6I1oE9LTPoXmKuLD8t85GT5t63t105hI5oaG0vsMH6EhEEFIHxVBG5knmbaA+LSkaC7LkjqpPVlGX2wMzG7QawFUACwE2rvSAhxK1CiMNCiMOTk5Or/XJEREs6M53Fls4ooqHq+6Vq8eq9/QBQsazXTdX899zZwd1cjXvuWJZJtPacskxX5m6laZmPnprGnv6EM2yklQUUgYFkBOOpAvKq+eZWzHrtTUaDzNwR1clqyjJvAHBKSjkppVQBfAXAawB0W2WaALANwIj18QiA7QBgPd4FYNHdj5TydinlQSnlwYGBgVVcHhHR8k5PZ+vWb2fbvymJ/mQED56Yqvp4sYYl5nZAWFNZppSQ0pwMSkRrp9oqhGBALLnE/MiZWTxwbAqH9rZPEdNgZwTj6SJyJSu4szJ3iTCDO6J6WU1wdxbAtUKIuNU7dz2AowC+B+Dt1jnvBfA16+N7rM9hPf5dybsNImqgszP5uq1BsAkh8GMX9OEHL0+ioC4uvayl505dVc+d+TLLgZlE/szlSvj9rzzjOehwlpgHKvfcaVWaXufzKm6583Fs6YriA9fvq88FN4HueBg/fHkSN37shwDKmbuOKMsyieplNT13j8IcjPIEgGetr3U7gN8D8FtCiOMwe+o+bT3l0wD6rOO/BeC2VVw3EdGqFFQdU5kitvfG6v6133XNDszlVHzliZFFj9UyLdPu00sVVN9rDezgjovMifz53KNn8fnHzuHTD5zydH7VzJ1SfVrmvz98GnM5Ff/07gMYbIOSTNt1F1ZWZFX03DFzR1QXwZVPWZqU8kMAPrTg8EkA11Q5twDgHav5fkRE9TI8mwcAbOupb+YOMIeqXLq1E3c+dBrvftWOisecPXe6ASklvAwNtjN3UgLZkuZ58IKU0snYcagKkT+dMfP37OwSw5EWqrbEvFrPXUkzcMeDp/HjFw7gsqGuOl1tc/iF1+zGzr4E3vdv5vqHqB3cRUM4Pe3t3zMRLa+1N2YSES1heNa8kdjWU//MnRACb7x0M14aTzulmaNzefyvu59EqlAurfSavXP37Pgp53Rn65i5I/LHzpKPzuU9nV9tiXkwIJygz/byeBoz2RLeeuUQ2tGegXKfczlzF2DmjqhOGNwRUVtay8wdAOy0dufZ7/r/8OVJ/OdToxUTL0vLTNFzUzUDyUjQ13MAVNxUMnNH5E/aeiNmdN5jcFdtibmiLCrLPDpq7sFst6ydbai7/IaaMy2TqxCI6obBHRG1pZG5PEIBgcGOyJp8/V3WFE57UfpEuug8FrbKtoqqt0CtpBtIRAK+ngNUBnRcZE7kT9oKNoZn8572Ujp77lyrEMJBsegNmedH5xEPB7C7zpN6m0XQVbYaczJ3IeRVfdmdgETkDYM7ImpLw7N5DHXHoCgr97zVohzcZQEAk67gLhn1l4VT9XLmzs8gFnfmjrvuiPxJWcGdbkicmMiueH71gSrKooDl+dEULt7SuWavPc0kHjZf1+zXxGxx5SCaiJbH4I6I2tLwbG7NSjIBoCseQnc8hM88eBrvuv0RnHeVdnVYNzLFKqsSFtINcyhK0hqi4iWDYDNYlklUs7SrP3bEQ99dtYEqwUDltEzDkHjhfAqXbu2s45U2n4s2dwAAokHz31XSqkzIlFiaSbRaq5qWSUTUjHRD4tRUFjddunlNv8/O3jieHp7HyFweXbHyhEs//XP2pL2OVWbu/K5QIGp36YKGjmgQ6YKGrIdhH/bvmztzFwooUF010edmc8iWdFyypb2Du7tvvRYvj2ecEs1kxHx9ZN8d0eoxc0dEbeeJs7OYy6l4zQX9a/p93NPf3AvInRJLD/1zdgDo5zk2g2WZRDVLF1Rs7TKHf6S9BHf64iXmC/fcnZw0yzv3DibrealNpzsexjW7e53P7bJMd7aUiGrD4I6I2s63nhtDOKDgxy8aXNPv8xOXVM8MdvjouVOtTF25T897WaY7oOMqBGpHuiHxR//5LL7+zKjv56YLGrZ0mwvGvWSUqvbcBRRohoS0fhdPTpnB3Z7+9hymspT+ZBhAZW8yEdWGwR0RtZ17j47hx/b1O9mwtfI7N+7HU3/yE86Ni81eQu5lZ529466WzJ07Y8DEHbWjiXQBn33kLH79P570HeClCxoGkhEoAr7KMt09d2Eri2f/Hp+czKArFkJvIrz4C7SxLVaG9Px8ocFXQtT8GNwRUVspqDrOzeRxYEf3mn+vYEBBdzyMPf2VJVjlyZcrZ+HUhWWZPnruDGbuqM253+B48Xza13PTBRUd0ZC5g81HWWZwQeYOKK9JODmZxe7+BITgpEy3nngI4aCC8RSDO6LVYnBHRG3FLvsZ7Iiu2/fcvaAEyymx9BCoOT13Ue8BoY2rEKjduUuf/fRz6YZEtqSjIxpERzTk7LxbTrWBKnagZ2fuTk1lsWeAJZkLCSGwqTOCMQZ3RKvG4I6I2oq9THxgjZaXV2PfzA11m6VHvXGzJCvl4YZxVZk7w12WyeCO2o87c+fl981m99h1RINIRAIeyzINBBVRkZWzSzQ13UC2qGEsVcDegfYeprKUzZ1RjC1RlnluJocJBn5EnnAVAhG1lckGBHdvOzAEQ5pTOkfm8ujvMIO7qczKwwNUzbw5Le/Gq3GJufenEbUMtcbMXbpontvppyzTkBVZO8Dcc2c/9tjpGQDAvjaflLmUzV0xPDM8V/Wxd97+CEbm8vjML1y95oOwiJodM3dE1FYm0+a7v4Od6xfcDXZE8f437HWyb7oBJMIBTKVLKz7XLitLhL1P2LTpBnvuqL25f19See+Zu7Qrc5eMhjyuQpAVw1QAIKSYn9/x4Cl84vsnMNgRwRsuZHBSzebOCMbmC1WrDOwl8p956PQ6XxVR82HmjojaykS6CEUAfYn1C+5s8XAAAJAraRjoiGDSS+bOujmNhwMQAiiqPlYhuJeYsyyT2pBdlpkIB5Dyk7lzgrsQOiJBjMzmljlXtb6X4WTqbHYm719+cBKAOUE3HOT76tVs6oyiqBmYz6voji+cMOx9mTxRu2NwR0RtZTJdRF8ysqh8aj2899W78J9PjuD6izfhnqdGMeVhp5Md3IWDCiJBxVfPnXuICoM7akf2709fMuJpKIrNDtjKPXdLv6ny/s8+gXOzOVw21FUxKRMALtzcgb0DCbz/DRdgIl3Aew7t8v+XaBObu8whV2OpwqLgzi5HZ3BHtDIGd0TUVibSRQyuY7+d2/5NHXj+wzcBAPqTEZyYzKz4HPvmNBRQEAkG/AV3LMukNmeXZfYmwjgxsfLvm62iLDMSWtRz98/fO44DO3pwYGc3Hjs9g5Jm4Mx0Dps7K6fwXjbUhft/+w2r+0u0CXvX3empLC7a3Okc1w3p/HfMlbxXLhC1K9YGEFFbmUgXGhbcuXktyyxp5cXIZuaOZZlEXtllmX2JMNJFzfObHOXMXQjJqDlQxZ4+K6XE33/nGO5+/CyeG0mhpBl402WbAaAhFQGt4vKhLvQmwrjn6cpl8wVXKTozd0QrY3BHRG1lIlVc10mZS+lPRjCXU53M3Ae/8BS+9tTIovPKZZkCkZDia1pmZXC3ygsmshiG9DQ9ciNQXZk7AJ6vO1WRubN6Za0gI5XXUNLNTN2RM+YEzA/ffBk+eMN+vP7CgbpefzsJBxW87coh3Hd0HDPZ8rApO7iLhhRkS83xc0fUSAzuiKht6IbEdLa0rgvMl2KvQ5jOlDCRKuCrT47gvxa8Yw1UlmWGAwqKnJZJDfZvD53GZR/6No77KHNsFHfPHQCk8t6GqqQLGsIBBdFQAMlICEB5991kxpy4e3YmhyNnZrGzL46Bjgg+cMM+/PnbLq/3X6Gt/MyBbVB1iXufH3OO5a3gri8RQUE1+FpGtAIGd0TUNmayJeiGXNc1CEvpt242J9NFZ//VS+PpRect6rmrNXPHGyKqk288ex4A8IG7n9zwP1eqqywTgOehKumC6uyWTFp/ZqzddxPWIKSZbAkPnZjGVTt66nrN7eziLR3oTYRx+Mysc6yg2gG6+d+Q2Tui5TG4I6K2MWHtuBtINj64s0tDpzJFPHbKDO7OzeSRKWo4NZXF6aksAKCku3ruQqvpuavXlVO7G5s3f4+eH01hNrfyrsZGWliW6XUdQrqgOcFdh7Wf0g4MJ11TbtMFDVftYnBXL0IIHNjRgycqgjs7c2f+N8wtM7mUiBjcEVEbsW/KNkLmzg4wXxhL4bFTM4hYu69eOJ/C//jXR/HBLz4FAFCt6ZjhgP9VCJq7LJMDVWiBgqrjo996ETkfmZDZbAkjc3ns6osDqPwZ24g0vTLr470sU3UydgkruLPXIUxlKgPagzt763KtZLpqZw9OTmUxbQ2ccoI76zWzWfo9iRqFwR0RtQ27nGoj9Nxt64nhtfv68dfffgkvjqXxrmt2AAA++q0XMTKXx/PWFD6nLDMofK9CcE/I3Ojlc7T+Hj45jY9//wQeODbl+TnPjc4DAK60ShFVHz2gq3VqKluRNfPCznzbZdDeyzI1dFi9dkknc2cGhpPpojMVsyMaxL7BpK9rouUdtDKhR6zsnVOWaWfuWJZJtCwGd0TUNuwbw40wLVMIgb95xytwwWASv3HdBfjjt1wCAHj89CzCQQUl3cBLY+nKgSpBBUXVe0mSxoEqtAy7vHJkNu/5Oc+NpAAAr9zeDaC8amA9/PynH8X/+eYLvp6j1ViWmSmWyzK3dptvBp2bzQEwX0c2dUTQlwjjwI4eKFx/UFeXbjV33B239oA6A1XsnjuWZRIti0vMiahtTKQK6IgGEQ0FGn0pAIDBziju/eDrnc//+C2XYDJdxHUXDeJn/+VhPD0852QegopAxAr6vDK4546Wcd4O7ua8B3dTmSIS4YATLGnG+mTuJlIFDM/msbXb+7UCVXru8j4yd1Ezc9cdD6M/GXamg05mzHUqv33jhdjU2fgqgFYTDwfRFQvh/Jz581lwTcsEuOuOaCUM7oiobUxmihtigflSbvmx3QDMJck98RC+/fwYAopAOKBACOF7WqbG4I6WMTZvBkrDVkbKC003EAoqCAXMbJW6Tpm7Z4bNctCpTG1lmZGgglgo4Ey8XEnKNS0TAPYOJJ3gbipdxJauKF63nzvt1sqWrqjz5sOizB3LMomWxbJMImobG2WB+UqEELhqZw8eODaF77806WTrzGmZtWXu1rE1ippELZk71ZAIKgqCinn74Kcs88WxFJ4bmfd3kZZnrOdNZ/xN59R0A6GAgBACiUgQmSVK+jJFDWenzSDXXtLe6QruLhg0gzsppZO5o7VjBnfmz6Vdim73TeZKLMskWs6qgjshRLcQ4stCiBeFEC8IIQ4JIXqFEPcJIY5Zf/ZY5wohxD8IIY4LIZ4RQhyoz1+BiMibiXRxQwxT8eIvf+YKfOHWayuOmdMyfaxCkMzc0dLGU/577lTNDJaCdubOR1nmTX/3AN7yjz/yd5GWZ4bnAADzeRUlH29wqLqBUMC81emIBpectPj/3fM83vrxByGlRLakQUo4ZZmAGdylChruf2ECU5kihrpjNf09yJst3bFFmTu7tJZlmUTLW23m7u8BfEtKeRGAVwB4AcBtAO6XUu4DcL/1OQC8CcA+659bAXxild+biMgzKSUm0xu7LNOtLxnBq/b04bE/uB5f+dVXA4DvaZksy6TlnJ8vQBHAbE71fMOsGRKhgOIETOs1UOWlsbQzoXI66700U9UlgtbzEpFA1b9nrqThm8+ex0y2hOHZvDNRc2FZJgD80l2HsbUrhvcc2lXrX4U82NoVxUy2hIKqO9Myy8EdM3dEy6k5uBNCdAF4HYBPA4CUsiSlnANwM4A7rdPuBPBW6+ObAdwlTY8A6BZCbKn5yomIfEjlNeRVvenKqQY7ozhgjZ0PBxWUNAPSY6BmcFomLSFT1JAuaLhoszmZ0GtppqobCAaEEzBp61Tvmyvp2GwNL5lKey/NVHUDYWuHZCJcPXN339FxZK1Sv5fH067grpy5u2hLBwAze/5P774SXfHQoq9D9bO5y8yMnp8voKDqCCoC0VAAkaDCVQhEK1jNQJXdACYBfEYI8QoARwB8AMAmKeV565wxAJusj4cAnHM9f9g6dh5ERGvs/hfHAQAHdvY0+EpqZy86L+kGIsGVJ35yFQItxV6DcNXOHhw9n8LIXB77N3Ws+DxNlwgpCoJW5k6t4efKMKTv9QGqbmBLVxQjc3lfQ1XcZZnJSBBjVimq2w9emkR3PIS5nIoXx9LoipmBmztzN9gRxYO3XYeBZMQJFmntbO0yA/mPfOMoCqqBmDXhOBlZurSWiEyreYUKAjgA4BNSyisBZFEuwQQASPPtZV+v/EKIW4UQh4UQhycnJ1dxeUREZV99cgTbemK4akfzB3deSzPdmTtWZZKbHdzt32SWG3oty7Qzd/a0zFoyd5kaMi+qbmCL1ec26SO403Tp9AcmlggMhufy2D/YgaHuGB44Nom7Hj4DoDK4A4Ch7hgDu3Vi/7f+zgsT+NHxKUSs4C4eCXCgCtEKVvMqNQxgWEr5qPX5l2EGe+N2uaX154T1+AiA7a7nb7OOVZBS3i6lPCilPDgwwDHDRLR6M9kSHjw+hZtfubWpFw7bNzg5jz0nFZk7RnfkMp83VwIMWqWOqscgTbV67uxpmbWsQpjPeVtHYJNSQtWlk83xk7kruTN30WDVIHZsvoDNXVEMdcfwyMkZ3PP0KIDKskxaX1u6KgdfxcLl0loOVCFaXs3BnZRyDMA5IcSF1qHrARwFcA+A91rH3gvga9bH9wB4jzU181oA867yTSKiNXNyMgNDAlfv6m30pazKJVbfz2OnZzyd7x6iwrJMcrP7lnri5pAKrxMo7dUCTuauhiXmdmDplR1AdsZCSIQDvnvuQkq5LHNh5k5KibH5ArZ0R/GK7V0AzFJVAE3Xn9tKoqEADv/RDXi9tUswapWhJyJB7rkjWsFql5j/BoDPCSHCAE4CeB/MgPGLQohbAJwB8LPWud8E8GYAxwHkrHOJiNacPSxiW09zjy9/5fYe9CbCuP+Fcfz0K7aueL57kqHXISzUHuzStm5rMEjJYwZO1Q1zz90qpmWmfAZ3dgAZCgj0d0R8Ze40XSIUtMoyw0EUVAOabjjXP50toaQb2NIZxTsObsfPXb0dFwx2oKDqiIZW7multdOfjDiv2fZ/i3g44Ay8IaLqVhXcSSmfAnCwykPXVzlXAvi11Xw/IqJa2MHd1ibfTRVQBH78wkF854XxihvUpejM3NES7OxHtzU8xGvmTtUloqHytEyv5ZxuvjN3mvmzGwoo6I6HMefj+e6yzETEDBCyRR1dcfOY3Xu4uSuGRCSICwbN7DgDu43Bfs22qxAS4aCzn5GIqmNnMBG1vJHZPHriIcTDqy1WaLzX7e/HfF7Fy+OZFc/VXSVz67SOjJpEvqRDEeW+Mq9BmmYYCLv33NXwpoHf4K5kXVswoCAWUlBQvQ/UsKd7AmZZJlA50MVelL2wx4s2BntZ/GzWLMVNRILcc0e0AgZ3RNTyRufyTZ+1s+3qSwAAhmdzK57rvl83mLkjl2xRRzwcdKY/eu+5M6dPBlcxLdN/z535PcIBc9eZn+BO1Q2nLDNpTb8cnsk5PYdj82ZWn8HdxmS/bs/k7OAuwJ47ohUwuCOiljcyl3feAW52dg+Kl6XT7sydwZ47csmVNMTDAQQUAUV4D+5KVjlwqIZpmfYQllqDu1BAQTRYQ3DnlGWawd3P3f4I/uzrRwEAo/MFBBWB/iSHp2xEW7vNoLugmj8D8XDQ87RgonbF4I6IWpqUEiOzeQw1+TAVW28ijGhIwcisl+CufEPNVQitq6QZ+MOvPosjZ7xNUQWAbEl3gp1wUPFelqlLhBRX5s7jtEx7nQEAXz1zQGVwFwsHnBt9b8+VztoGuywTAJ46Nw8AODGRwabOaFOvSGllmzorM6rJSAAl3fD8ZgRRO2JwR0QtLZXXkC3pLZO5E0JgqDvmOXNnZy1Yltm6Pvadl/G5R8/ic4+c9fycvJW5A8ygqehrFYKCgDNQxdvPlbs3z3fPnWugSjSkIO8zcxd2Tcu0nZjI4I4fncK9R8dx46WbfF0PrZ9QQMErtnXhj37yYgBw+qZzVUoznzg7i123fQMnJ1fuRyZqZQzuiKilDc+ZvWmtEtwBwFBPHMNeMndSloM7xnYtKVvU8C8/OAEA6LZ21nl7nu4EdxEfmTvVkGZZps9VCO6vX+sqhHBQIOKzLFMzyr8D7sxdSTfwl996EYf29OGPfvISX9dD6+trv/5j+KXX7gHgmnhaWvwz8P2XJgEAdz18Zv0ujmgDYnBHRC3NLl9slYEqgNl35y1zV76x5SqE1jSXV53AvaB5D3rMnjurLDOg+FiFYC4xDygCQngvy7TXGQCr67mLhQMo+ijLLGlGuSwzWjktt6gZeOuVW50sJG18dilxtrg4c7fZKuH80fGpdb0moo2GwR0RtbRRKwhqlZ47wMxCzmRLVUuT3MzgzrwJ50CV1pRxLXQuVMlmLMXsubPKMn323NnBUkhRPJdlqq4gMONzCbVdlhlUzIEqJd3w/GZFRVlmpLy7Tljx3Ov3D/q6Fmosu7S2WnBnZ3SPT2SQKvh7A4GolTC4I6KWNjKXRySooC/hvWRto3MmZq5QmqkZEooQCAjBzF2LyhTLN7F+etHyJb0yc+e1LNO1WiAYEJ5XIbiDRz9lle7nhoMC0ZDi62toRjkYjQTLwd2O3jgu2tyBzVyB0FTsUuJqu+7cmesXRlPrdk1EG03zb/QlIlqGvQZBiNYpvdq/qQMA8PTwPPZZH1djGNIadS/Yc9ei0q4smJ/gLrtgoIqvskwrWAoqwvMSc7ssMxYKoOBz0uHCskzA/LsmIivfwqhaeaiQ7YLBJP70py51vhY1D6css0rVgnuKaqZKZo+oXTC4I6KWNjJXaKmSTAC4cFMHeuIhPHxiGm+/atuS5+nSvAFXFJZltir7JrYvEUbeR1lmrujK3AUVlDyUVxqGhCHhrEEIBfwMYjHP64gGfd94L9xzB3jP3JVcmUYAePC269AVC1UMV6HmYQd31UrSi66fCQZ31M5YlklELW1kNo+tXa0V3CmKwLV7+vDIyWnIZYI23TCgKCzLbGV2/9pAR8RzwKPqBkq6gYSVuTIHqqz8XDtAszNhZlmmv2mZHdEgCqq+7M/tQnbgGQooiDhlmR57BA3pZBoBs1+VgV3zsn9mM9XKMl0//2mffZ1ErYTBHRG1rIKqYypTbLnMHQC8em8fRubyODuTW/Ic3ZBm5k4IZu6awLmZHCZSBV/PsTMUAx0Rz2WZOSvDZ5clmkvMV/750Jwgy+q5U5SKQSnLscsyk9EQDOl9P575fa2eu4CCWMh75s4wZMXEWGp+Tuau6kAVAx3WRFRm7qid8RWPiFrW+XnzRrmVdtzZDu3tAwA8fGJ6yXN0a6CKogguMW8Cr/3o93DNn9/v6zl2hqIvEfYR3JnPsW+UQwHhqefOzr450zL9ZO6sILDTuvn2s7bBKcsMCkR9BHdOpjHYOv227c4O7qvtuStoOnriYSjC/0RWolbC4I6IWtZLY2kAwPbeeIOvpP72DiQx0BHBwyeXD+6C1k4y3Ufm7jtHx31nkKgx0gUNyUgQ8UjQc6miPWkwXpG58xLcLcjcBRQfe+7KZZmAv4mZ7rLMcnC3+PtKKZF2jcB3rlfhrU6rUBSBeDiw5CqEWCiAZMR/XydRK+ErHhG1rP96ZhS9iTCu3NHd6EupOyEEDu3pw0Mnlu67s1ch+JmWqekGbv33w/jsI2fqeLW0VjJFFclI0JxC6XGgipO5C9uZO2/TMu1ALhgoT8v0vOfOOq8jEgIAX4vI7cAwpJTLMqtlKb/+zHlc/qf34t2fegS5klZ+XoCZu1aSiASrDlQpqAaiIQUd0RB77qitMbgjopaULqj4ztFxvOWKLS3bc3Nobx8m00WcmMxWfdyQds8dPJdl5lQdhgRmcqV6XiqtkUxRQzIaRDSk+O65c2fuvOy501wZNPtPv3vukjVk7irLMpfec/e1p0agCOChE9N49OSMU5YZbNHf/3aVCAeq77lTdUSczB2XmFP74iseEbWkB49Po6gZeMsVWxt9KWvm0B6r726J0kxNl+a0TMX7tEx7nP58nu981+rEZAbffn6s5uf76Y+0yzJjoQA0Q3oqr7SzHvGIa4m5h8xdSa/MhAUDPvbc6QvLMn1k7tyrEJboucsWNfzw2BTeftU2CAE8OzLvZAvDDO5aSjwcrF6WqRmIhgJIRoNVgz+idsFXPCJqScOz5hTJC5dZ8t3sdvbFsbUriodPTFV9vKQbCAcUKMJ7z13OCe74znet3vz3D+B//vsRX+P+3fyUlGWKGjqiQSfo8ZK9q9Zz5ydz5wxUUXzsubPLMqNmWaafgSol5/suPVDlgWOTKGkG3nblNuzuT+C5kflyWSYHqrSUZCRYdYl5UdURDSpIRoJIs+eO2hiDOyJqScOzeSTCAXTGWnenlRAC1+7twyMnZ6pme2azJfQkwlAUwGucYWd15lmWWbOiFXzqDRsAACAASURBVFTUOtRh1se/+4ydubMCNS99d3YAaPevhQOKEwgtx5mW6c7c+d1zF/FflqlZb1IIUS7L/OQPTuLPvn7UOefe58fRHQ/h6l09uGxrF54bmcfdj58DYA4fotYRjyxdlmln7jIFvjlF7YvBHRG1pNG5PIZ6YhCitd+1P7SnDzPZEl4aTy96bDpbQl8i7GuJeZ6Zu1ULKObP3ES66Pk57iyfr+CuWC7LBLxl7uzAyg4IQx4zd6pr3xxg9rKp61SWaZeC2pm7kbk8vnT4HKQ0S1G/88I4rr9oE4IBBZcPdWF0voBP/uAEfu7gdlyxrfUGKrWzoe4YTk1lF/V7OgNVOC2T2hyDOyJqSSNz+Zbcb7fQUvvuSpqBdEFDbyIMxccqBLssc47BXc26Y2bp4aSP4M4dfM/lvP+7zxTMgSqxZVYELGQHd1F35k6XK5aR2v11duYupAgfA1UWlGX6GqgiEQqWh7gEreA5VdAwnS3hsVMzSBU0vPHSTQDM3wlFADdduhl/+JaLPX8fag6H9vYhU9Tw7Mh8xfGCZmXuIkHuuaO2xuCOiFrSyFweW9sguNvWE8eO3viioSp29qfXytx57f+yyzJTeZWLz2vUHfcf3LlXCnjN3BmGRKakoSMaQjTsPXOXL5kBWdQKmMLWnytl7xYuMa+lLLOWaZkl3XC+JwAormz8iYkM7n1+DNGQgtfuGwAAXDbUheMfeTM++fNXodMKJql1XLvEICl3WWa2pHuuViBqNQzuiKjlZIsa5nIqhnpaP7gDzNLMR05OV9zMTGfMAKEvETYHqnhdhWBl7gyJth9KMJcr4W/ufclzdsrWHQ8D8FeW6Z5WOZP1FtxlSxqkNPvYokEruPPQc1fQdIQCwlkRYJdZrrSzTquyxFz1usR8YVmmhx4/57magbBrV507CD0+mcG9R8fxun0DTpkpYC67ptbUn4xg/6ZkRbWClNIsy7QGqgCoOnSFqB0wuCOiljM6lweAtijLBMwypXRBw9HRlHPMDhCcskyP99I5V3DwxNlZTGdWDlBOTWXxuo9+D+fn8/4ufIP72/texj9+9zi+8ex5X8+zp1D6ydy5AxavZZl2X1HCPVDFU+ZOd4JBoBysrbQOwb2SALDLMn0uMbeCu6LPPXd2WeZC9zw1ivPzBdx46WbPX4+a36E9fTh8etb5mbWHGEVCAednjKWZ1K4Y3BFRSzlyZhY/8bEfAmif4O7Ve/sQUATec8ej+NExcy3CdNYMLPqSYQQUc6G5F+7Mz/s+8zh+5hMPrficLx85h7MzOfzHo2d9XXdB1TGRKvh6znqyy/+mMv4mh9o3nBNp738390oBr2WZedcycj8DVYqa7pRxAkDYCvRWDu4qe+6CNSwx74jU2HNXZVddRzSIR0/NQBHA9RcNev561PwO7e1HXtXx9PAcAKBo9ZpGQwEkrMwdh6pQu2JwR0Qt5ePfOw7ALFW7YLA9RqAPdkbx2VtehXg4iH/87jEA7sxdBIoQnoO73IKyvtPTuRWfs6M3DsBc3u3Hr37uCVzz5/f73gc3Opf3FTjVqtMajOJ3cqgdyPjK3Gn+M3cF54ZWKQd3XsoyramCNjtzt9LOOs1YkLkLCF/TMoUwr1URtUzLXHy7ctXOHgDA/37jRehJhD1/PWp+1+7phRDlQVL23sRoqFyW6WdfJFErYXBHRC1jPFXA916awPvfsBdPf+hGp/epHRza24d3Xr0dj56awchcHjPZEhRhTm701XOnVt4Q2TdKy7G/9PEJf8Hdd1+cAACk8v5uwn7ri0/hQ1973tdzatFplXf53flnZ7j8DVTxn7mzb2gjoQCiYfN/594GquhOMAiUB6oUV8jcaa5l4uaffjJ3ZvbN3FUXWDZzNzZfGbiremXPne3P33Y5vvQrh/D+N+z1dA3UOrrjYVy8ubMc3NkTYIMB502ZuWV+jzJFDWnuwqMWtergTggREEI8KYT4uvX5biHEo0KI40KILwghwtbxiPX5cevxXav93kREbt989jwMCbzjqm1tOVDh5lcOATD7kKazJfTEzX67gOI9c7cw87PNw1Aau3/q+ETGVxbO7o0Z81maOZdTfe2Cq5VdlrkumTtXkOQ14+C+oS2vQvA2UCXqDu6cgSrLB2qlBT13fqdlhpTyrjo7MF3oxGQGh/7ifjzimoS4sCzz1tftwTuv3o6t3TFcvavX0/en1nNobx+OnJ1FUdNdWeyAU7Hx4tji3Z+23/rCU/itLz69LtdJtN7qkbn7AIAXXJ//JYCPSSkvADAL4Bbr+C0AZq3jH7POIyKqmzPTOXREg9gz0B7lmAvt6Ivjki2d+P5LE5jJlNBrlaoFhIDHoYbIlXTnecDK4/GB8uRDQ/qbENlnfR+/wV1JM1bsD6sHO9jxG9zZ/85mciXPwa799+mIBD1nFMr76hQnWKtloIqzCsFj5q5clulvWqY9FCUaVJYsyzw1mYWUwAvny8OBSrrh9PkBwB+8+WL8xc9c4en7Uuu6ZncvSpqBZ4fnK34XOqMh7OqL47kFe/Dczs7kcGY6u16XSrSuVhXcCSG2AfhJAP9qfS4AXAfgy9YpdwJ4q/XxzdbnsB6/3jqfiKguJjNFDCQjjb6MhnrNBX148uwcRufzTpAmBDwvMc+XdGdPG+Bt4pw7oDjhozTT7pMa8zlls6gZK5YQ1oMd3Pld6G4/T8qVSx3LzzH/+/Qlwz4yd+Vshb3c20tZZkEzFgxUWZy5e99nHsOnfniy4nl2z50zUMXntEw7KFyuLHPc6qUcns27nlu9547am521ffTUjCu4M3+uLx3qWrTk3C2VVzGTZVkmtabVvlr+HYDfBWD/H6EPwJyU0v4/0zCAIevjIQDnAMB6fN46v4IQ4lYhxGEhxOHJyclVXh4RtZOpdBH9He0d3L36gn6UdAPPDM9jd38CAMyyTM977jTEwwF85n1X482Xb/Y0cc4dwKR89LH0xu3gznu2z/5+fjN3f/edl7Hrtm/gK08Me35OyQpc5j0OOLGpWvnftZcBJ0A5sOpNhD3vF7RvaO2SzFg4gGzRQ3BX0p0F5kA5E2f/OzUMiR8dn6oojXQ/HnKWmCvQDOkpO+kuy4yEAktm7sZT5s/CuZlcxXPDDO5ogd5EGPsGk3j89IxTPWAPCrp8qAvDs/kl++7m8mZpt99hTkTNoOZXSyHEWwBMSCmP1PF6IKW8XUp5UEp5cGBgoJ5fmoha3GSmiIE2D+6u2dWLoCKQjATxgRv2ATCDO6+Zu1xJRzwcxI9fOIgLN3UiV9JXHMbizsKkfEyos7+q/7JM3VO5qG0qU8TffcecIrrcu/kLOb1zHnb9VVyfKxjJeRz5bwdOvYkISpqB4hI9aW7uzB1glnRmPQSGBU2vWPjtlGVaf9/pbAmqLjEyV5lR1ayfg1DQDNLsYE3z8MZBRVlmSFny72evxjjnytxpS6xCILp6dy8On57FrDUdOGKVG1+2tQsA8NxIatFzVN1wXtf8DnMiagarebV8DYCfFkKcBnA3zHLMvwfQLYSwx6ttAzBifTwCYDsA/F/2zjtMrrps/5/v9Lq9ZnfTe0I6oQUpoQoKIkhRLFgQRVTsoj99xVde9RVfUSxRsAECihRpSgkQQgppkJ7dbJLNZnsvs9PP748z5+zMbJsNIZvyfK6Li93ZU757snt27nM/z/0kvp4NpD4WFARBeAc0d0tZptdp42sXz+B/r5lPabYehqKPQshs/75IzBzC7ctwGHAoGjfj9EczONgQT42jFHehaNyca5UJye5ZU9coEiwTgqs7GB3dXLZo3Ezsy9S5M4RVgc9hnnMkkvuMQP/3ynS/lJ67NOfO+PeoT0utNJIxbUnOnf76yD9cyQLNZRumLLPLKMvsd+7CwwwxF05uPriojJ5QlN++uhfof9AxIV8fz1LXMbDkO7mHtu0oBDMJwtHmsO+WmqZ9S9O0ck3TJgLXAS9rmvZhYCVwdWKzjwFPJj5+KvE5ia+/rIkfLgjCESIYidEdjJ70zh3AzedM4ZK5JebnFsUoyjL7xZ2RZtkdGr4sMRiJUZAQ1aOZLWWUc6ZH3w+HpmmEY/FROXfJvWSjEZLJ+7WMwr0Lx+Jku/Vrl6koTC7LhMyuY19an5HfZc+ojLYvHEuZc5fu3BmirrMvkuIERsxAFZXy/0xCVcKxuDlCwWUfOlDFCOTpDkbNcli9505a9IWBLJ6Qx/kzi8xkTMORHm5GZYq46xVxJ5x4jDzAaPR8A3hYKfVDYDNwX+L1+4C/KqWqgDZ0QSgIgnBEMN58n+zO3WBYLZnPudNnoOl/GvyJGXcjCYZQJI7HYcXjsI5qdlS6U5QJeo/XyMmOKedJiBaHzWIGdmS2X/81a+wKUp7ryWi/SKzfuUsfCj/kuaLp4m7k62iMoHAmxJnPaRt2tpdBeqBKes9dcsBNfWcfU4v8gP59WS0KIwvNEGuZOHeRWNwUkcMGqnSFyPXYaQ9E2NnQxWmT8ohENem5E4bkv94/h2lFPvK8DsZluwD93qXUyOKuXcSdcAJyRO6Wmqa9omna5YmPqzVNW6pp2lRN067RNC2UeD2Y+Hxq4uvVwx9VEAQhc4yZYgX+k2dweaboZZmjC1SB0ZRlxnDarPgzLAs0iCT1eGXqcBluXyY9aQaGaKnIddPYFco4RMEQMwCbazoy2icW14hrkG2UZY7SucsfTVlmNI7LbjHFlt9lGzGMJRbXCEfjKWWZxVlO/E4bz29rAFJ7IOs6+j+OxrUUB62/LHNkoZ2ceOmyWwe9LpFYnNbeEIsn6CmI161Yy6MbDkpapjAsFXkevvXeWdx8zhTzd8FiUWS57CM7d1KWKZyAyN1SEIQTAkPcFfpcY7ySY4/RibuknruEczeS0AhGdJHhc9oyKgs0SHbf9rVkNnPK2CcS0zIuNTXFXZ6HcDSe8dy6SCxORa6bSQXeAcmRw+0DkOUabc+d/r3keY3y1pHXGIykDiPPRFwbojg5UMXjsPHp90zmPzsa2VzTTn1n0BRxyT1LeuJlcsqmUZaZiXPXLwzzvA5aekIponBPYzdX3rsaTYNzZxTy1YumM7nAy/2v7yccTZ1zJwiZkO22D5re2yXOnXCCI+JOEIQTgpYe/Y+09NwNJL0sc0ddF3c+vWOAWxaLa4SicfONvz8hUEZyg/qdu8HfTA1FOBZnapE+cD5TcZfs2GXad2dsV5Eoq2zMMFTFcIxOn5zHun1tGZW2GufKSvTc9UUyE7uGAM0fRc9dejCK32Uf0WU1xKYrLaDkpmWTKPQ7+c4T26ht72NWaRZKQV1SP2Q0pqWILG9C/HdlIJbD0X73bV55NsFInD2N+kxETdP4zuPb2F6nJxuWZLm49fxp3HzOZHY3dtMdikpZpjBqst3i3AknJ3K3FAThhMBw7oyyNqEfi6U/LbM7GOGzD2zkvtf3cf/qfSnbBcK6MEgPVBlJMBjO3ajLMqNxZhTr/VzVzZkNP092+zIdEN7v3OnpoZmOXghHtYS4y6c7GGVn/cBY9aHOZZZlhjMdYn4YZZmJ627gc9roi8RSgmAG7JNYX7JzZ+z7X++fw/a6Ltbva6PI76TI7+RQex9dwQgdgTC9oag5Uw9gSqEuzKsyGFzf0hMy+wkXVOQAsOVgB5qm8etX9rJ+fxs3nTWJC2YVsWC8/vX3zy9jerGP0ybl8b7540Y8hyAkM6S4SwT1FPgc4twJJyTvRqCKIAjCUae6pYeSLJf05gxCabaLf71Vx32v76Ouo4/a9gBzxmVx78tVXH/qeHK9xjBxXfQUZ+mlrT4zUGV4ZyYU1csDlRoYnz8c4VicbI+dkiwX1aMsy0z/OJN9+p27zNZozGYzRExdRx9zy7JH3AeSyjIz7blLrDHXM7q0zPSyTNDFuPFvmk4wLWEzmUvnlnDb+VO55+UqZpVmEYtrvLm/jVse2EgkqhGKxZlU6DW3n1TgxaKgcgRxF4trNHQGKc/VxfX4PA+5Hjvff2o7P/vPblp7w1w2r5Q7Lptl9jiCLkD/8+VzRrwOgjAY2W47dZ2Dj0LwOKwU+l209WZeaSAIxwsi7gRBOCHYVNPOwsQTfyGV2y+cTk1rgDuf3oHNovjgonJuPGMC7//Val7Y2cg1i8tZVdliJjuOz9NFkMdhxaIy67lz2iw4baNLywxF9WHfkwu9VDdnWpaZ7NyNboackXbZmKEAjcTiOKzKFLmZJF9GorpF2u/cZViWGYujlJ586bZndh2DkRjOJJHmS0o3HUrcGWWZTttAcaeU4vaLZnDt0vHkeRw8tqmWlbu3UdMWwGGz4LBauGpRmbm9y25lQr6XqqbuYdfZ2BUkGtcoy/GY5ynOcrGroZsJ+R6+celMrl5UjsUifXXCkSPLbR+0ZLizL0K2206e105bb+YjTgTheEEecQuCcNzT3B3iYFsfi8bnjvVSjklcdiu/uH4BSybkYrEobls+jVPKsinLcfPvbQ2s3N3ER+9fbw4CNsSdUrqwGVnc6Q7S4aRlOmyGuOvJKMUydBjOneGm+Vw28r2OQZ/mD7Wf3WrB49SFUG8GQs0Qkh6nDZtFZezchRPnUkplfB1DkTjupLJMo0dyuL7HwQJV0inLceN2WFk+q6h/fdE4PaGo2SNpMKXQR2Xj8M5dbbt+vcsSzh3AJ5dN4tSJufzxE0v50JIKEXbCESfLbaOzLzLgvtKREHc5bgddo7hfDcYfVlVz/+v7Rt5QEI4i4twJgnDcs7mmHUCcu2Fw2qw88KnTaOwKUpEQbxfPKeGBdQfMwJQtBzvwOqxmbxRkNhg7FNWdO5/LRiAcIxqLmzH5wxFOOHdF+V66glG6+qJke+wj7mN+nGmgSrR/zl15noeDbZmJu3BMw+Ow4HXofyp7M0gCNYSkw6pw262Z99xFNZyJa6aPNMjAuYvG0v6tRu6RNNaTHqgyGKXZbhaNz6G5J2Res6mFqeJuWrGPV3Y3DTuu4FBHANBFo8E1Syq4ZknFiGsQhMMl220nEtPoi8TwOPrf7nb2Rchy2/E6rSP2E4/EM1vr0TQ9kEgQjhXEuRME4bjmtT3N3P3CHuxWNWI/1MmOUUZncNWiMjRNY/2+NvO1ijyPOSsKIMdjN8NqhqLfudOFWW9oZLcqGosT13TBZZQwZpK0mVyKGYqMUtxZLYzP81DTFshov0gi4dEIEcnk+zLEnd1qwe2wZp6WGYthtxnizn6YaZkjj64weu6Gc+6S+eMnlvL0rWebwS3pzt30Yh/RuMaf39g/pPN6KOHclSc5d4LwbmPeV/pSfx86A7pz53PaM3pgMxyhSHxUCcGCcDQQcScIwnHNr1ZWUd8Z5AvnTxs0JEIYmrll2Tx16zI+cvp4M43QKMk0mFHsHzYlUtM007kzxEUmb3YiibludqslI1FicDjOXSjJuavIdVPX0ZfRWAO9bFRhsSg8DquZJprJ+kxxl+Gcu0i0fw6c32XLqFxMD1QZWJY5nNPaN0ygymBku+1ke+zMLMnC77INGDVyyZxSzp1RyA+f2clziSHo6Rzq6KPA55DfT+GoYoi79MTM1t4wBT4HPqeVnnA043mZgxGOxQeIR0EYa0TcCYJw3BKPa+ys6+LyeaXctnzaWC/nuGRWaRY/vPIU3jOtAIAJ+anibva4LJq6Q0O6d4Zwctqt+DMceg6ppZI+58iixNwvSdBl6twZQtJhtVCR5yEa16jPoO8uudTQ47DRm4FQCyc7d3YrveGYmUI60rkcCeeu0O+kOYNET30UwsBAleHCWEznbpRC66NnTOBTyyanuLqgO4D3fexUJhd6+eXLVURice5dWcXrlS3saewmGIlR296XUpIpCEeDwcRdPK7RHgiT73Xic9nQNAhk2Bc7GKFoTJw74ZhDeu4EQThuOdgeoDsUZc44Kcd8p8wr1/sVk8s2AfPabq/r5NwZRQP2MwRWcllmJiItFNPfUDkSvXr6fhmUZUaSnbsMw0qShKThTNa0Bcz0zKGIxDRT3HmdVgIZ9dwlhKRN4XZYeWFHI6/ubmbVN84zR0wMRihJSJbluGnoCg7bxwb95bAGpgM6zDqNmXSeDMsyDa5aVD7k16wWxS3nTOFr/3ibK361mh1JTu8Np41nd0M3Syfljep8gvBOGUzcdfZFiMU18rz9TnJvKGo+GBkt4WiccDQ+4HdREMYSce4EQThu2VGnv4mcMy5rjFdy/DOjxM9vPryIDywsS3l9duLaPrbpELsaBpZnGj1wKWWZg8SPp9PvpqnRlWXGDmPOXSyG1aKwWpQ56642g1CV8GE4dxGzv89qumPhWJzNNR0j7udIEndxbeR5fKE0585ps2C3qkGvo6ZpPLy+hhWrqnnf/HHk+5wDtnknfGBhGTeePoEd9V3cdNYk7v7QfM6eVsBD62po6g5x+bzSI3o+QRgJQ9x1BPoHlbcmRh/k+xx4Eym4o0n4Tce4B4l7JxxLiLgTBOG4ZXtdF1aLYkaJf6yXckJw6SmleNOeYGe77WS5bPzrrTo++Os32N2QOtMsmOTcFST6sVp6Rp4dleymjaacM5RUQhXKeBRCfz9baY4LiyKjUBVjzh2AN8OeOzNQxaZSSh+3Heoc+VyJssxxiRJGI4gknQOtvSz54YuEY/GUnjt9jIKdnmCUrzz6Fjf96U0z5GTFa9V8859bOX1SPj/54LwRv4/RYrNauPPKuaz91nK+e/ksrlpUzu0XTgegOMvJBbOKj/g5BWE4SrJdeB1WNiU9WGnt0YVevtdpPlR6J6Eqxj1I+u6EYwkRd4IgHLdsONDG1EKflMO8y/zwA6fwpQum4XHa+OLDm1NSEZOduyK/E6WgPoMes3CSw9VfljnKnrtMnbskV8xutVDod47oikF/Wiboc+syScsMp6VlGrw9grhLdgmNeXB1nX10BiJsrU3dd211qymg03/2S7JcVLf08NimWl7e1cTnHtzEj5/fxYrXqjl7WgEPfOq0jJMyD4eSbJfZl7egIoerFpVx+4XTMxqNIQhHEqfNyrkzi3hhR6MZoNTamxB3Poc54iST+85QGPex9NCW0fDgugM8v63+sPcXhHSk504QhOOS3Q3drK1u42sXzxjrpZzwvD+RpFma7eIbj21lU00HiyfoA+OTnTu71UKBz5lxgAiAPTEPzqKGn89mED6MIeahaBxH0siAbLc940RPYzyB12GlIaMQlv7wFleac2eI4vRQEkhNyyxLcu5+9sJuHlh7gKduXWaO+jDKkWHgvLpFE3J4aF2N+fkLOxqJJt7YfvacKViP4rBwpRR3f2jBUTufIKRzyZwSnnm7njPueolbzp2CLfHzn+9zEE/8Pg5VMRCMxPj5i3so9Dn58GkTBjwUicU183frnZRl3vH4NgD2/89lh30MQUhGHqUJgnBc8sfV+3DZLdywdPxYL+Wk4bJ543Dbrfxj40HztWDUiNbX/5yUZrtoSLhiz22tH9IhSx5PoJTC57RlFsQSPTznzpkkgrLd9hHLqDRNG9hzl4lzlzQKwfh4Qr6Htt4wq6tamfu9f7Pl4MD+u3CsX4C67FbyvQ5q2/t4YUcjcQ2+8djbRBOCeGd9f2lssmgFWDIhDyPZ/ekvLGPL9y7iKxdO5/3zx3HmlPwR1y8IJxLnzSyiwOegLxLjp//ezY7E706ux4HfaczlHPxesOVgB797tZofPrOTlbubBnw9+eFSJn3GIxF8B6mdgpCMiDtBEI47+sIx/vVWHe+bN45cr2Osl3PS4HPauHxeKU9sruPXr1Rx+S9XmW6bMyEySrJcNHQGae8Nc8uDm7j/9X2DHstw7hyjHNx9OM6dnjrZ71hluewjllEZT+TNnjvnKHvurMosnbzsFD1MZMWqanrDMR7dcHDAfnrpaP8ay3LdvLizkfrOIBfOLmZ7XRf3vb4PTdNS5g7ub+1NOY7hqPqcNmaVZuFz2vjC8mncc/3CQR1DQTiR8TltvHnHBTz9hWVEYxp/W19DjseO3WoxA1WGeqiUXEkw2P0iRdy9g1AWgx3DzBMVhNEg4k4QhOOOl3c10RuOcWVasqPw7nPLuVMIx+L85PndbDvUxat7moFU566+s88UILsbuwc9Tn/Pnb6f7txlMAohGjdjyzNOy4z2h5VAZmWZkaTeORhFWqYZqGIxZwNeMLsYm0WxqlK/Vs9vazBduOT9kscelOe6aekJoxTcddUpXDi7mJ+/uIc39rbSHYpy2/JpTMj3cM3i1BEF5bluirOczK/IPqolmIJwrKKUYkK+l/NmFgKQ59EfCI7U65v8+mDuntFvDEfGuXtrEEdfEA4HEXeCIBx3PPXWIQr9Tk6fLGVmR5vJhT6uO7UCv9OG02bhma16EIDh3BVnu+gKRtl4oB2APQ0jiDvTucu8LNNlt2KzqJQ3V8MRjqWKuyz3yM5dJKo7d+acO4eVcDRuirfhzgW6aD1vpj4XcGqRj+nFfjRNHx7e1hvmintX87H717Nhfxsf/sNaKpt6UsTYly6YzqfPnsS3L51Fgc/JnVfMxWax8Om/bADg4jnFvPq185hWnJoUq5Ti1x9ezPffNyeTSyMIJw2XzC0BoDaRQuu0WbFbVYbibuC9JpTi3A1+P6lu7uGin7/Kmr2tQ67LSNUdrFxbEA4HEXeCIBxXdAUjrNzdzGWnlIozMUbcecVcVn3jPJZNLaC5O4TNoijw6U/DS7P1Qd0vJ3pU6jqDdA/yxifdGfO5bBmXZTptFhw2y+icO2uquOsJRYnHtaH3SXLgQE/LBAiM4N4li8KvXzyDjd+5gCyXnVMSYSg3nDae25ZPI8djZ9uhTm74/TpWV7VSluPm1In9g76nF/u547LZfPo9kwE9hfKOy2YRjsb5wRVzzOHyg7F4Qu4A0ScIJzvnz9DHcSQn7vqctiF77lLE3SAl2Sniboge3t0N3exp7OH636/lUMfggUzGejIJohKETJC0TEEQjiv+s72RcDTO+xIJaif4pgAAIABJREFUjsLRx2JR5HgcXLOknE017fzsQ/PNodglWXrS4+aaDpw2C6FonMqmHhaNz005Rjit587ntFHTOvLsOcOFM46dCeG0kscslw1N01Pysj32QfcxewKT5twBBMJRczjyUPsZA9NBmdfllPJsHtlwkAUVOebP7trqVq5bsZazpxXwl5uWjtgTd/3S8Vy5oOxdHWUgCCcq2R47P7hiDpMLfOZrPpdtyJTenmAUi4I8r2NQdy+TQJXke9TGA+1mEq5BNBY3xzQEM7yfCcJIiLgTBOG44skthyjPdbNofM5YL+Wk55K5pVw8pyRFlJTn9r95uWBWMc9sraeysXuAuAul9dz5XTa6MynLjMQOy7kzBhYDpjjrCkZGFHfJc+5g8PKs9P2Sw1sMLpxdzOuVLZw9rcB87fTJ+TzymdOZUeLPOOxEhJ0gHD4fPWNiyudex9D3nZ5QFK/ThncIdy+l526IsszkBMza9oEPr1LmdkpapnCEkLJMQRCOWdLTCTceaGdVZQvXLK6Q5L9jhPR/h4o8D7/9yCI+uKic25ZPw+uwmv13yaSnZfqcQz9BT6bfubOmvDEadp+0UQhZCXE3XN9durhLdu6G4hcvVvK716pTXEKD4iwXv71xMTme1HTX0ybnD3hNEISjg981fFmm32nD6xh8m+RQqPZAeNBjGOJOqf5ev8GOAZmPdhGEkRBxJwjCMcm2Q53M/6//mI3omqZx59M7KPI7+dTZk8Z4dcJwXDK3lJ99aD4zSvxcNq+Uf71VP+DJ9sC0TDt9kdiAFMl0QhG9f85hsxx2oIrp3A0j7sJpgSoex/DO3eOba/n5i3uAoYciC4JwbDHcfM2eYBSfyzbkNsbDpeklPvY19w7aw9sX0beZWujj0EjiTpw74Qgh4k4QhGOSFa9VE4lpZnz827WdbDnYwReWT8PrlIry44WPnD6BvkiMR99Mne02WFomjFz2mNxzN7o5d8k9d5k7dw5b/5w7GNy529PYzbf/uY0FFVIqLAjHE16nbcj7QH9ZpnXwtMyEcJtXnkNvODaoM2c4d1MKfYOWZRpunctukZ474Ygh4k4QhGOOhs6gGbG/uUaPh350w0FcdgtXLJAgleOJeeU5nDU1n//9z2621naar6eXPRpu2r60odzpJKdlZhyokpaWafTZDTfrLn19OW69dLKhqz/R7p6XKnlw3QE++8BGvE4bK25czHtPKeHUibkDDygIwjHH/PIcDrQG2D3IyJaeUBTfMD13hnM3v1xPrt3ZMHAIeTCq9whX5Lmpbe9D01LdPeMeluWyi3MnHDFE3AmCcMyx4UAbsbjGqRNz2XKwg7N/8jIPrqvh0rmlpusiHD/84rqF5HkcfPHhzayrbmXjgTbTdTPCR5bPKiLbbeen/9414A1QMqFoDIfNgsM6UNy9tLORC+5+lb60cQXpQ8yzEi6h8cT+rmd3cutDm1L3SRN3FXluynLcrNylO8n1nX3c/cIe7nh8GzWtAe69YSFFWS7uvWERf//smaO7QIIgjAkfXFyOw2bhwXUHBnytJxTFP0xZplEWPrcsG6VgV/1AgRgMx3A7rJTneghF47T0pPbmGffBLLddnDvhiCHiThCEY46qph6UgqsXl9MXidHcHeK25dP4ykXTx3ppwmFQ4HPy46vnUd3Sy7Ur1nLNb9fwwLoaHDaLGciS43Hw5QumsbqqlTeGGPgbj2s0d4fIdtvJ8zpo6kqdC/XK7maqmnoGDANOF3c+pw2rRdHVFyUai/Pwmwf59/aGlGS7SCy1504pxQWzini9qpnrVqzhu09sB/S5db+8fiGnTc43txME4fggz+vg0rklPLH50ICeuZ5gv3M32HxLQ5jleBxMzPeyazDnLhLHZbOaKcLppZnGQyS/y0Ysro3YcywImXDY4k4pVaGUWqmU2qGU2q6U+mLi9Tyl1AtKqcrE/3MTryul1D1KqSql1NtKqUVH6psQBOHEoqqph4pcD2dPK8RmUXz1ohncfuF0ynM9Y7004TA5e1ohX1w+jZvOmsSZUwpo6w0P6Jm7bul4CnwO7nt936DH2NXQTXsgwtJJ+cwqzeJAWyClXGp3o/7kfOOBtpT9wrHUskylFFkuvddm44F2OvsiRGIabyeXjaYFvgAsn1VMMBJnbXUbL+5sZHyeh/++ci6XnlJ6mFdFEISxZtnUArqCUaqae1JeTxmFEI4OWVLptFmYXuxjT+NA564vEsNlt1CarYu7+rRB5UYpplGRIu6dcCR4J85dFPiKpmmzgdOBzyulZgPfBF7SNG0a8FLic4BLgWmJ/z4D/OYdnFsQhBOYqqYephR6GZfj5s07LuBTZ08e6yUJR4AvXzid//e+2dx11SmDft1lt/Lh0ybw8q4m7nt9H5FYnMc319LUFSQQjrK6qgWAM6fo4k7TdMEHepqq0TezIWn0gqZpA9IyAQr9Th5aX8OXH9mCzaK7bb9aWcUfVlUDST13tn4n7owp+Xxq2SR+evU8HFYLF88pFqdOEI5zFk3Qe2TXVbeys1533+Jxjd6wMQrBiqYxwL1LDoUq8DnpCAzs4Q1GYrjsVrPPN33ci+HcGeNZgofRd/f8tgbueamSykHEpXByctiRc5qm1QP1iY+7lVI7gTLgCuDcxGZ/Bl4BvpF4/S+a/uhjrVIqRylVmjiOIAgCALG4RnVLrznsOdcrM8BONCryPFyzuJyatoHpcTedNYk397dx59M7eHDdAaqbeynLcdMRCNMbjlGc5WRcjhvjGfqO+i4WVORQ1dRDZ18El93CpgPtxOIa6/e1sXB8DpqW6sABrLhxCY9sOMjTb9fx/vnjeHzLIV7b08xre5o5b2bRgJ474+PvXD4bgKWT8ijyu96dCyQIwlFjcoGXbLedHzy9A02Dtd9ejsuuCzqfy5Y0BiWaktSc7Nz5XXa6ghE0TUt54BOMxnHZrfgSx0gfmG723CX6gA9n1t3tj24hEI6xbl8rD37q9Iz3a+oOyj3sBOWI9NwppSYCC4F1QHGSYGsAihMflwHJWdi1idfSj/UZpdQGpdSG5ubmI7E8QRCOI2rbA4SjcaYW+cZ6KcK7yE+vmc8jN58x4PVsj50HP3UaX71oOtXNvbxneiEdgTAzSvw4rBauWlQOwLhsF1kuGzvru/jSI1u4+P9eA+DKBWV0BaP86NmdXP/7tdz60GaAAc7dxAIv37hkJqu+fj53X7uAj585EYfNgtWi+PuGWjP6PF0UGkzI9+JODDYXBOH4RSnFwvE5RGIa0bjGG3tbTYfN69QDVYABoSqhpNLtLLeNSEwbIM6C4Rhuu9UcpZLu3IWi78y5i8U101Fcs7eVlp5QRvvtb+ll6X+/xC9erBzV+YTjg3c8LEop5QMeA76kaVpX8hMLTdM0pdTQsWeDoGnaCmAFwJIlS0a1ryAIxz+rKvXSu6lF/jFeiTBWKKW49fxpnDeziBnFfiIxDZfdQize/1RcKcWs0iz+taUu5Wn4Z8+ZwmObarl/9T7sVsWLOxuBVAduML572Wy+cclMvvC3zdz3ejWapoct5IlzLAgnPBfMKjbd/zeqWphdqv/98TmTnbtBUniteiiUP9Ez19UXwWXvf+gTjMbI9zqwWS247VZ6QpEBx4D+njtjdl6mGGLwAwvLeHzzIZ7f1sBHTp8w4n6NiTCqn7+4h5uWTTTXL5wYvCPnTillRxd2D2qa9s/Ey41KqdLE10uBpsTrh4CKpN3LE68JgiAAcLAtwF3P7mTppDwZCC0wZ1y2/qbIYUUphc2qO2sGX7t4BpOLfCydlMfTX1jG9943m4kFXs6eVoim6QPUjVEL6c5dOhaLwmW38tWLZnDtqRXcfM5knvvi2SllWIIgnJh85PQJrPr6eZw+OV937hJCzu+y9btuA5w7fYYd9JdVdqU5c0bPHeglnunH6B+FoO8fjI7OuTNcu0XjcyjLcbOmevCk4XT6khzCl3Y2DbOlcDxy2H+1lP749D5gp6Zpdyd96SngY8D/JP7/ZNLrtyqlHgZOAzql304QhGQe3XCQvkiMn1+7IOVNvCAMxpKJeTz5+bPMz+eW6cOEr1gwjpd3NXHlgjJaesL86626YQeWJzOjxM8Prxw88EUQhBMXpRTnTC/khR2NfOeJrQB4HTaz/Dp9kHnyiBXDeUu/z/RF9LJMAL/TRnd6WWbsnTl3xkxPt8NGgd854PhDkRwOY8z7FE4c3olzdxZwI3C+UmpL4r/3oou6C5VSlcAFic8BngWqgSrg98Dn3sG5BUE4AXlxZxNLJuZRluMe66UIxzHvnz+OlV89l/kVOdx01kQAJuR5x3ZRgiAc81x7agWfP28KTV0hrlwwjlPKs033vjc8sF/OcO78CecuXVwFI3Gcwzh35igEo+cuzblr6gryx9X7BoxhMAhE9ON5HFZ8TiuBQYatD7pfkrhLX9NzW+tZv68tfZdB0TSNV/c0E4tLF9WxxDtJy3wdGOrR+vJBtteAzx/u+QRBOLGpbQ+ws76Lb7935lgvRTjOUUoxqUAXcwvH5/LW/7vILHsSBEEYCrvVwtcunsnXLu7/O5Sf6Ls9mJbum+Lcuft77pIJJubcgd6/N9QoBEMcpjt3/+/J7Ty/vYFF43OZP0irgiHS3HYrHoeN1p6BCcSD0ZckVNPF3S0PbgJg152XpPQPDsbO+m4+dv96/viJUzlvRlFG5xbefY5IWqYgCMI74dmt9Sz/2auAPihaEI4k2R67zKMTBOGwyPE4mFeezcu7UnvTksXd0M5df1mmzzlMz505CmHwnrt9Lb2Dvt5flmnF57QNmMU3FL2J7Zw2ywDBafDXNQdGPE5HIAxAc3dmKZ3C0UHEnSAIY87fNxwkz+vgdzcuZkqhjEAQBEEQjh2Wzyxm88GOlFEDeqCKLtwG67mLxbVE0u/Q4i4UjWO3KtyOwZ27oiwnALuHGFBuiDuPw4rHYR3QF/jm/jYeXDdQpBkisMDnHLAmQ4y+sKNx0HMmY+yb7lgeDSobu/nzG/uP+nmPB0TcCYJwVOgJRYnEUv9wdQYibDvUyRt7W7l4TgkXzykZo9UJgiAIwuAsn1WEpsHLiWTJnlCU3lDMdO48DitWi6I7SdwZYwrMsswh0jIdVovZu5fec2ccY0dd16DrCkT6xZ3PaUvpC9xU0841v13DHY9vMx02c79QFLfdSpbbnrKmeFwzkzTrOvtGvC6GSOwIHH1x949NtXzvqe3S7zcIIu4EQXjXCYSjXHT3q/zw6R0pr3/3yW1c/svXCUXjnDujcIxWJwiCIAhDM2dcFpMKvDy2qZZoLM5l96xi/f42U5Tps+5sdPX1CyVDJKWUZQajKeEoRmmn4e6lO3eG8NpZP7i4M3rn3A59Hl8wEieaeIj68Poac7stBztS9gtEYnideghLclmmsWarRdHYFSQ+gnAyxORYJG4a6w6EMwuROZkQcScIwrvOn984QF1nkJeSehbC0Tgv72rCovR+g9Mn54/hCgVBEARhcJRSXL24nHX72vjTG/s50KoHl7y5vz9V0u+yDercJadlRuMaoWi/gDNKO03nLpLq3Bk9fE3doZSSUIPkQBVjHp/h5nX1RSnLcWNRsKkmVdz1hWNmn16yc2eItamFPiIxbdBzJmOUgXZkKO7+tHofl/9yVUbbjoRx7vTh8oKIO0EQ3mVicY3fr6rGZbdQ295HTWuArmCE57bV0xOK8svrF/HC7eeMmMolCIIgCGPFBxeVY7UofvTsTkqyXACcM70/ITLLZedAW4CNB3TBF0y4cK6kOXeQGrpiOHd2qwWrRQ0oy0weil7XMbBMMpDUc2eObEiInu5QhJJsF9OL/WyuaU/ZrzcUxeuw4XXaUvr0AgmhNLVI730/NMg5U4+jb5+pc7e9rotth7oG9AYeDkYoTPqICkHEnSAI7zI767to6w3z6bMnA/DctnquvHc1X3x4C06bhfNnFlGc+EMpCIIgCMciJdkufv/RxZxSls1ty6ex7b8u5lc3LDS/7nfZ2FzTwbW/W0tnX8R04dxJzh2kjh4Ix/oTN502y8CyzGCE8lx97mtT10AXrS8cQyl9X485bF0/b3cwit9lY9GEXLYc7EgpB+2L6M6d32WjezDnLiHu6juDw14ToySyM62n7/tPbeeZt+sHbG8EzowkGtP58iNb+O9nUts6DIEYEOduADL4RxCEd5W11a0A3HDaeP6+oZa7ntuFzaL45LJJTC3y4XaIYycIgiAc+5w/s5jzZw4+rkclRj9H4xqvV7ZQnEi67J9zpydq9qQ5d0ZJpstuHeDcdQejzCzNora9j+ZBSiT7IjE8ditKKXwJ584QXD3BKOPzPEwu8NIdjNIVjJKdmMcXCMf6Q1iSxJ2RvmmIu8HcwmR6hnDuHnnzIHUdfVw2rzTldaMnsbY9wPRi/7DHTmbjgXbTmTQw1p0eUiOIuBME4V1mbXUbE/M9lGa7+e2Ni3l5VxOnTszl7GkSoCIIgiCcGGxKlD7arYqVu5u4YsE4IDVQBVLFSCg6vHPXHYwyucDLa3uaB3XuAuGYOUbB40g9flcwit9lJ8ejD2HvCIRNcdcbipLn9eBNzMaLxTWsFmWWOo7LceG2W6nryMy5S+65C0Zi9EVig87mM0RgbfvIzt0Zd73EjWdM4HPnTqUjEKalJ4SmaebMUuP7lECVgUhZpiAI7xqBcJR1+1rNsJQFFTncfuF0EXaCIAjCCcVPr5nPZfNKuXhOCa/sbqY9MR7A7LkbpCwzlBiFYGwXTApbicbi9EVi5Hoc5HrsNPcMFFp94Shuh+EMJpw7sywzQpbLRq5HF3TtSeMK+iL9zl3ymgKJ/3udNsbluKgfYRyCUQLa1RcxkzUNAXegLTBgTIFRlmmIu8017Uz85jN8+ZEtKWEywUiM+s4gP3l+N7G4RlcwSiAcS3EvjXP3Zji4/WRCxJ0gCO8av3q5iu5glA8uLh/rpQiCIAjCu8b754/j3hsWcd2p42nrDfHdJ7YB/eLOKCtsT+pPC0fjZpqm7tz1CxVDcPldNgr9ziGdO4894dwl0jJ7w1HC0TihaByf02Y6d8nn7Q3p4s4QnGbypBHQYrcxLsedUpYZjsZp7EoVmMZ+cQ2zd8+YeReOxgeUdXaZzp2eNrojMeLh8c2H+PUre/u3S0odbevtX3dNIqU0Zc3DlGXG4xrffOxt1uxtHXKbExERd4IgvCvsbe7h96uquWpRGadOzBvr5QiCIAjCu86yaQX87EPzKfI7+fx5U5hU4AWgLMdNabaLv6zZz8Pra9jX0pvi3DnTnDsjVdPvslHkdw3Zc2f0rfvMtMxYijDM8/aXZZr7haN4EmmZMLDE0eO0Mi7bTV1SoMr//mc3p/3opZTxCMklkYZwSxaRyaWZ8bhmCkDDuWvp1re9ZE4Jv3t1Lw2J8yXPC1xT3S/M9ifEnaZpZviLIe5C0RiPvnmQUFLf4vPbG3j4zYP87392D7h2JzIi7g6T7mCE9/5iFW/Xdoy8sSCcZGiaxvee3I7LbuVbl84a6+UIgiAIwlHjAwvLeeH2c/jaxTOxWvQeMYfNwjcvncm2Q118859bufLe1dR19PUHqqQ5d8nibijnri8RjAIkpWVGzXl7fpe9vyyzV39N0zQCQ5VlJpw7r8NGaY6L5u6QKZaMmX6Pbjhonr8nFDV7Bg3HriOp/HN/a7+46w5F0TRQql/ctfaGyHbbufX8qYSicdYnzpHs3L2wo9H8+EDieH2RGEbFp7Hml3Y28fXH3ub7T+0wv897V1YBMC7HPeDanciIuDtM9jb3sqO+i1d3Nx/2Meo7+zjtRy+yu6H7CK5MEMYWTdO467ldvF7VwtcunkGh3znWSxIEQRCEMef988fx/ffN5jcfXkSBz0FnXyQlLTN5Bl6yQCvyO2lOBIokEwjHzMAWI1ClNxxNEYZZLjsW1e/cBSNxNE3f3hR3wf6eO6X0hM9x2bogauzURaXLpp/ngTUHTEcuEI5RlhBORq9dZ1+/c1fd3C/uDGdvYr6Xtt4wwUiM1p4w+T4H4/M9ADQkevy6kgJa3qhqMT82nLuUweuJj43z/219Dc3dIdp6w2yv08s+O9JGNZzoiLg7TJoSdceVTT0Z77OzvovPPbiRX75USTyusau+m8auEG8dFPdPOHFYVdnCitequfH0Cdx4+oSxXo4gCIIgHBMopfj4WZO49JRSHrvlTC6dW8KZUwsAmFeeza6GLtoTPWbpzl04Gk8Zag6pZZlWi8JttyacO307n8uGxaLIdttpSwgcs/TSYR0we683HMPrsKGUMt2uuoTgqu0IUOh30h6IcNk9q2juDtEbijIuR59TaxzfCG6ZWeLnraTqNkN8TUuMWWjqCtHcE6LA6yTLZcfntJnpnMb3meOx05q4HmU5bmoSzl1v0mw7ozyzubvf2XxzfxuNSU5nct/eyYCIu8OkKfFDNBpx9+/tDTy7tYGfvbCHyqYemrr1H+K6EdKIBOF44lcrqyjNdvHdy2ebkcWCIAiCIPST43Hwm48s5upE4NjyWcXENXhlTxMA3aF+586ogKlKe88ZCEfNckzQQ1t6wzHT9cty6SWZuR6HKbqMMkb3oGWZ/ccrTYi2+s4+YnGN+o4g1ywu50+fOJVAOMammnZ6wzFmlmRhtSgqG/UqtI5ABLtVceHsYt462GGKOqPUclqxLu4auoK09oQo8Os9gaXZ/emchnM3Z1yW+b3NGZdl9gD2pjh3+veT3AvY1BU032NPLvAOK+7SEz1PBETcHSaGuNvb3JPxD0Z90ryQ6uYe86lC/QhzRIajMxDhu09sGzYtSBCOFs9trWf9vjY+857JZh2+IAiCIAjDM68sm0K/k1++VMUXH97M/71YCehBKWdMzqfA5+DzD27iYFt/YqQ+jLx/ZLXXmercGWmYOR67WZqY3FeX63FgUVCbOKaRogmYZZl1HbpQisY1ynLdzK/IwWpRbNjfRiyuke9zMKPYz5ZEFVpnX5gcj4NlUwuIa7A2EYjSZTp3+vDyxq4grb1h8r26cC3NcVNvBKokhODs0n5xN7M0y+wBHKwss7k7xORCL3aroqErZDp5M0r8tPaGB5S0Aty7sopTvv9vsxrvREHefR0mzYknAuFoPOUXbTjqu4JMLtRTk6pbeo+Ic/dqZTN/XXtg2JjXUDTGQ+tqWPHa3pQnG4JwuGiaZj7UCEfjrK5q4RcvVvKVv7/F/Iocrl86foxXKAiCIAjHDxaL4rpTK2gPhNmwv50Dif6yLLeNoiwXf/3kafRFYlz/+7U0dgXpDkboC/eXZYIu2HqCUVP8GM5crsdhBqokl2V6nTbmlefweqKvLZBI0QTd2cv12Knr6ONQIgClLMeNy25lerGftdVt5jnnV+Tw1sEO4nGNjkCEHLedheNz8TisrE4c20jANJy7Qx19dAQi5PsSzl2WyxR3nX0RHDYLUwr1bbNcNipydbHZ0Bk0BZ3dqkyx2tITosjvpMjvSjh3/eIuHI0POg/vqS11BMIxPv/QpsP4Fzt2sY28iTAYzd0hbBZFNK5R2dTDxETUbTI/enYn1c29/OFjSwC9UXRqoY/eUJTq5l7TNm/ozPyJgaZpROMa9kR0rlF/nJxIlM6tD20204Ze2NHINy6ZyZaDHXzq7MkZn1cQQP/5u/uFPfzpjf0EIzGmFProCUWpbe9DKThjcj4/v3aBOddHEARBEITM+MpFM/jKRTMAfaZbeyCMMxFkMqs0i79+cinXrVjLDb9fS2NXSHfTkpIgZ5Vm8eSWQ4Rj+kgFf6IsM8fjYGdiptxz2xoAKMnWyy7fM62AX62sorMvQiAcw+vs//tdmq27aYcS8+rKc/Xgk3ll2TySSM30OKwsqMjmb+tr2N/aS3sgTI7HjsNm4bRJebxemRB3ife85bkenDaLuZ58n+HcuWjpCem9hX1Rslx283w5Hof5fR7q6DPFa5HfZX7c0hNmzrgsfR5fd5Astx2/02bu19YTNsWugYb+kPrN/e10BMLmTMDjHXHuDpOm7hALKnKwKNh6qHPQbV7Z3cTrVc2mw1HfEWRcjptJBV6qW3poTDxVqB9G3N317E5u+tOb5sDHv6w5wLQ7nmPlbr0m23iyU90yuLiLxzVWV7Vw3akVfHLZJN6q7eQPq/bxw2d2DhhGKQjD0dQd5Fv/3MovX67ijMn53HTWJEqzXYzP8/Dbjyxi43cu5KFPn05xlmuslyoIgiAIxzXj8z3Mr8hJeW1eeQ4/v3YB1S29zC3L4rFbzuTDp/VXynzv/bMZn+9hVWULVosy2yNyPXbaAxFW7m5ixWvVfPi08cxKlDwum1ZIXINVlc30ppV5VuS5eetghynQDKE0ryLb3MbntLGgIheAl3c16c5dQiSdNbWA6pZeDnX00dkXQSnwO22UZLvMJMvChHM3LtuNpunlml3BCFluG+UJty7HY+8PeOkImn12hX6n6UQ2d4co8DkpznLR2BWiqTtIYZbTdAZbe1Mr1zRN42BbHxMTSZ1DvY8+HhHn7jBp6gpx9rQCQtE466oHlkSGojH2NvcSi2scbAuQ73PQHYpSku0iHIvz7NZ6PAl3oycU1X+QXXZe2d3EzJIsSrJd9IVj/HnNfoKROI1dQZ657Wz+9VYdADf/ZSNrvnU+BxIlofuaB/+hrG3vIxCO6ULUoghH46yq1Mc3/Gd7AzeeMTGj7/e/n9nBrNIsrlpUnvE1isbi2KwWIrE4NouScI1jmJW7m/jNK3u5aHYxoA8ePXNKAV3BCM9uraehM0h1Sy+apvHpsyfx7ffOkn9PQRAEQTjKXDynhHXfWk6Bz4nFkvp3OMtl59uXzuJTf9mQkgeR63XQF4lx20ObmVWaxXcum21+beH4HMpy3Hzvye209oZ57ykl5tduWz6N61as5e8ba1k6Kc8sAb1kTgl3PL4NIFGm6WPZ1AJ+8vxuwrE4c8bp4m/ZND0J9Ncrq9j0o4sOAAAgAElEQVTT2K2PZbAoiv0uc6ZdsnMHuuHR1ae/Jy7NcaEUZLvtptNY19Fnjn8o8jvZXhciGNH78IzgmdcrW8hx6yMk8hI9femhKq29YfoiMd4zvZD9aw6wr7mXReNzD+8f5RhDxN1hEI9rem1vlpMcj50/rzlAMBJjxWvV5Hkd3LB0PFVN/UErexq7mRzXyzZLs13YLIqOQIQOIlTkuTnY1kd9R5BOR4RP/OlN3jdvHPdcv5BX9zQTjMQ5Z3ohr+5p5lBHH7saullQkcOWgx2s3N1MTcK5M8oy43GNHzy9g6sXlzO3LJvdifSi6SV+jFuAUXf8fJK4a+8Nk+vtt6M7AmH+sbGWi+eUkOd1cP/q/cwty85Y3B1sC7D87lcp8Dpo7A7xkw/O4+xpBTy3rYGlk/LMJ0ZHgnXVrUTjGmcl4oSPVTRNo7MvMqTt3xmI4HPZzIGnR4tnt9bzuQc34XfZWL9Pv9m67VYeXFcD6ElT04v9XDSnmKsXVzBpkBJkQRAEQRCODkXDVMgsn1U04LXTJuUxpdBLjsfBL65bkNKnZ7da+Osnl3LtirUD9pszLptHbz6DXQ1dXD5vnPl6vs/JL69fyG0Pb2ZSgRelFL+6YSEf/sM6ttd1mSJrRrEenmK8n1g6MS+x/v75t/mJ954T8/X3Fk9sOURXMEqO247TZmVctptCvxOX3UqBz0l9Zx9Ffv37L/Q76Q1HzfCUQp8TpfSB6ftbA5w5Jd88fmuauKtJmCNnTingoXU1VLdknn5/rCPi7jBoC4SJxjWK/C7Kc938ftU+HlpXw90v7AFg44H2FKFR2dRj/iKVZLkoze6vj55fnsPBtj72NHazva4LTYP/7GiguTvEI2/WkOOx89WLZvDqnmb+sKqanlCUj505gfrn+njm7ToauoJ4HVbqO4MEwlG21nbypzf209AZ5Lc3LmZ3g257Ty/2pyQFTSn0sra6jY5AmNVVrXzx4c08/6WzmVrkpzMQ4YK7X6OlJ8RD62v4+sUzicU1th/qTGm2HY411a2Eo3GUUvhdNp7YcogfP7+Lpu4Qy6YW8MCnThvxGHUdfXzhb5vZ29zDHz9+KgsHeaLSEQhz8wMb8ditrP7m+bxW2cKTWw7x3ctmp4jVZBo6gxT6nUddRD226RDf/udWXrz9HHNgp0EwEuPc/13JVYvK+e7ls4c4wpGnuTvEHY9vZX55No/cfAYH2wLkeR1ku+28sruZkmwXc8ZliUsnCIIgCMcBSilWff08cwQBwJKJebz0lXOH3GdyoY9nblvGz1+oNCt4DGaVZg36QP5988dx+bxS8/1BjsfBU7cu4/WqFuYmRhgopbjzyrnsb+nl8+dNJdut9wB6E+8jZ5b4mZAQdRV5Hm4+ZzK/e7XaPD7Aio8uNh+Kl+W4qGzsob03gsdhxe+yEwjFaE6EBRb4Hdis+nqMgJW8xHvBdOfOCEOcXOhlfJ6HfS29rN/Xxvef2s491y9gaiLV83hEeu5GybZDnXzuQT1VpzjLyZKJeTisFu56biceh5Wb3zOZxzcf4qt/fwvQxdyexm5z3MG4HDenTszFkQhEOXNKASVZLm5/dAv3v76PifkegpE4y378Mit3N/PRMyYytyyLAp+TB9YeAGDJhDyWzypm5W69vNIYgFnZ2MMzW+sBve65MxBhd2MP5blufE4bfped0oStfdvyacTiGi/ubOKBtQeIxjWe3KKXfL6yp4mWnhBfvWg6Na0B83uJxjU212Q2cH1zTQdZLhurvn4el88rZVVlC03dIWaVZrF+X9ugoxs0TaMtKa72Z//Zw7ZDnYSjcR55U2/cDUZS047+78VKOgIR6jqDHGgN8JtXqvjnpkO856cr+cCvV7O1tpMr713NX9fsJx7XqOvo4z0/XclnH9hIJNFwDHoZbSYjLWJxjcc315phOKPhkTdrCMfiPLHl0ICvrdnbSnsgwl/W7Df7Kwdj26FO/ra+JqO1VjV1pwz1TEfTNL79+FZ6wzF+9qH5uOxWphX7yfc5sVktXDC7mLll2SLsBEEQBOE4oiLPw9yy7JE3TKLI7+Kuq07hvJkDnb+hSH9/YLUozpleaJZaAtx4+gS+e/ls8rwO86G6kRz/3x84JeVB+9cvnsn4PP3hd1ZijMOccdlmr9/scdlsONDO89sb+NCSCrwOK+FYnAfX6s6g0XNnUOh34nFYcdosvF3bwVNv1fGXNftZW93Kznq9sq0i18PkQi/Vzb0883Yde5t7KEkyYY5HxLkbJW6HlebuEF+6YBrnzijCZbdyz/UL+eLDm/nwaeP55qUzCYRj/HXtAeaWZVHoc/LyziZer2zBZlEUZTlRSvHDD8zl6/94m3nl2Tz7xbP59coquoIRPrlsMnc8vhWHzcJXLprB4gm6W3Xh7CL+tv4gs0uzKM91c/2p43koYXNfuaCM1/Y084k/vUkkGmdqkY+qph5ufmAD2+u6TBscYGqRj45AhMvnjePHz+3ij6v3sb2uC4uCZ96u5/YLp/PK7mbyvA4+d+5UWnrC/OmN/ZTnuqnr6OOXL1eyrrqVLbWd1HX0cc3icj599mRq2gL8Zc0BfE4rnz13Cptr2lkwPheLRXH2tEIeWFtDgc/JNy+dycfuX8+ava0sn1VEOBbHbrFwoC3ANx57m/X72shy2ZhU6GNrrZ7o2dgV5PntDXz2nClc+evVfOLMSXzxgmm09Yb52/oaTp+cx9rqNp7b1sCb+9u5cHYxDquFZ7bWc8uDG6lt72PLwQ6z5zAcjfPCjkZ+88pebls+DU3TuH7FWmJxjYc/cwbhWJxNB9rpCkaYV56TUob4/LYGvvzIW7xneiF//Pipw7p/mqbR2BVidVULlU09vLm/HYuCJzYf4gvnT025Kb6wsxG33UpM07jz6R389iOLU74ei2v8z3M7+f2qfQC8uKORO6+cazYYp/PYxlq+8djb5Hgc3P/xJcwrzyEe13h+ewPPbWugvqOPrmCEPY09fPu9M4/rJ1SCIAiCIBw/fOKsSVw6t3RAFZPVorh6cTl3v7CHruBAE+DOK+Zw2SmlWJRubKzf10a+18Fjm2p53/xxzBmXbYYFOqwWzpxSgFKKj505kRWvVfPs1oaU4xX4nLgdViYVeFlV2UJLT5jzZhQNSNU83lCDDfU7VliyZIm2YcOGsV7GADRNG/C0oisYwevo75fa09iNy2ZlT2M3f3xjH3leJ1cvLuec6YXmPq09oZSnG8MRisZo7QlTkuUyG2gPtgV4ZU8zH146nqrmHn783C4qm3r4n6tO4cWdTby0q5HxeR6+/d5ZpqX+0s5G9jb38Jn3TOH7T23nT2/sx+e0cdNZE7nn5SpuO38qD6yr4Zzphfz82gU0dQc596evcPXicnY1dLMh0QCb63EwpcjH+n1tLJtaQFVTD229YSLxOEsn5rF+fxtfXD6NL10wna5ghFN/+CIfPWMCX714Bgt/8AKTC72EInEqm3pw2ixE4xpuu5Wblk2itSdETVsAt93Kjz84jw0H2vn0XzZQkuWioSuI227lic+fxWObalnxWjUvfPk93Hjfen1wZyjKY7ecycKKHM768cvUdwa5fF4pTd0hqpp6KMtxE47GKcvVE6BWf/N83tjbwk1/0n/OirOc+vcR6/+9uGBWEWdOKeCG08Zz+6NbeHFnE+FonEvmlPCVi6bjddqoaQtQ2dTDlEIvexq6qWru4e3aTt6u7U9StVoUt543lV+8VMnC8TlMyPNw6qQ8uvqi/H5VNUsn5rFwfA53PbeLm86axNQiH+2BMM3dIVZVNrO3uZePnD6eiflefvL8bpSCn14zn/cllUV0ByOsrmrhlgc3sXRiHrXtfbT1hjltcl5CsEYpznIyucCHx2Fl0YRcPnvOlKNeoioIgiAIgpDOwbYAZ/9kJTefM5lvXTprxO2jsTjtgYjZ5wd6SWaup98p1DSNxzYdwu+yMb88h92N3exu6GJCvpeL55Sw8UA7161YQySm8asbFqb0Fx4rKKU2apq2JKNtRdydvLT0hHh5ZxPnzCgk223nK39/i2fe1ss6771hEZfNKwX0WSu5Xjtuu5VoohzQalHYLIr7Xt/Hiteq9Y8/firb67r41j/fJhLTePgzp3P65HxAT18szXbhslt5eH0N97xUic9l4/J548xhlZ84a6LZJJtMOBrnu09s4+m36/jIGRP4w6p9ZlniBbOK+MPHTuXOp3dw3+v7KMlysfqb52O1KO56bie/e7Wa+z62hJJsF1f9+g1C0Ti3nT+V0yfnc8Mf1lHgc9AdjFLgc/KVi6bz8q4mSrNdLJ9VTK7HwdNv1/HYxlrqOoNMLfJR2x7g2iUVjM/38sNndjDUr4/HoTf+fvSMCSyZmMf4PA8tPSGmFvr469oDPPzmQVp7QuaQzdJsFz+5eh5nTSng9ke38ORbdeaxPQ4r88tzuG5pBVcsKAOgtj3Alx/Zwpv72/G7bMwo9lPod/LizkYiMY3ZpVn845Yz6AlFufWhzRxq7+OcGYWcPjmfy04pFTEnCIIgCMIxSfJ7xqPFCzsaeWxjLT+/NjVw5lhBxJ1wWGiaRlVTD9G4xswS/6h6rZLdzJ6Qnlz0bqUqrtnbyv7WXoqznJw5pQCX3WqWQNqsioKEG9rSE+IfG2v51LJJ2KwWDnX08fimWm44bQK5HjvfeWIbXcEouR477z2l1BSig/HK7iZ+9OxOKpt6ePxzZ7GgIoe9zT28XdtBMBKnNNvFlEIfr+xpJtdj57JTSke8fpqmsbe5l0Kfk2yPPeVrTV1BQtE4RVlO7BbLgLhj0PsPH998iB11Xexu7OZAay/nzyxiYUUuF84uHjJQRhAEQRAEQTh+OKbFnVLqEuAXgBX4g6Zp/zPUtiLuhGMJTdPoCUXxu+wjbywIgiAIgiAIR4DRiLujmpaplLIC9wKXArOB65VSRy/3XRDeAfpYBxF2giAIgiAIwrHJ0R6FsBSo0jStWtO0MPAwcMVRXoMgCIIgCIIgCMIJx9EWd2XAwaTPaxOvmSilPqOU2qCU2tDc3HxUFycIgiAIgiAIgnC8cswNMdc0bYWmaUs0TVtSWFg48g6CIAiCIAiCIAjCURd3h4CKpM/LE68JgiAIgiAIgiAI74CjLe7eBKYppSYppRzAdcBTR3kNgiAIgiAIgiAIJxy2o3kyTdOiSqlbgX+jj0K4X9O07UdzDYIgCIIgCIIgCCciR1XcAWia9izw7NE+ryAIgiAIgiAIwonMMReoIgiCIAiCIAiCIIweEXeCIAiCIAiCIAgnACLuBEEQBEEQBEEQTgBE3AmCIAiCIAiCIJwAKE3TxnoNQ6KUagYOjPU6BqEAaBnrRZykyLUfO+Tajy1y/ccOufZjh1z7sUOu/dgi13/sOBav/QRN0woz2fCYFnfHKkqpDZqmLRnrdZyMyLUfO+Tajy1y/ccOufZjh1z7sUOu/dgi13/sON6vvZRlCoIgCIIgCIIgnACIuBMEQRAEQRAEQTgBEHF3eKwY6wWcxMi1Hzvk2o8tcv3HDrn2Y4dc+7FDrv3YItd/7Diur7303AmCIAiCIAiCIJwAiHMnCIIgCIIgCIJwAiDiThCEQVFKqbFegyAIJw9yzxEEQXjniLgbBKVURnMkhCOPUqporNdwMqOUmq2U+iSAJjXbRxW574wdSqnisV7DyYpSaoZS6lKQe85YoJSaoJQaP9brOBlRSrnGeg0nK0qp3LFew7uJiLsklFIupdRvgJVKqR8opc5PvC7X6V1GKeVTSv0MeFYpdbfxx16e5B4dlFJWpdQ9wKOATynlGOs1nSwopTxKqZ8DTyulvpl037GO8dJOeBL3nf8DnlNK/U4pddVYr+lkIeme/zdA7jdHGaWUO3HfeQ74s1LqlsTr8n7nXUYp5VVKrQC+p5TKT7wm73WOAom/t/cCzyulvqCUWph4/YT6uT+hvpkjwE1AEXAOsA+4Xynl0jQtPrbLOrFRSk1HFxU24APAfuAzIE9yjyJTgBJN0+ZqmvYLTdPCY72gk4g7gBzgEmAr8FellFPTtNjYLuvERilVBvwVUMB7gVeBn4zpok4SlFJZwD+BZZqmLdI07cmxXtNJyG3AOE3TZgPfB74EIO933l0Sbt0PgGWAHzgP5L3OUeR2IB/4GOACfgcn3s/9SS/ulFK+5E+BNZqmtWqa9kdgDfCj/9/evUdbOh52HP/+xq0IstRaCRFGXBpxqctgiSAq7iLRVoJWQyoXq2iqRIIsRkhdqrWCjEuqY0qUUkQnJeK2mLUsIyEuq4Iuk05dssyMDHVnfv3jeffYTs6MOefss59z3vP7rLXXnP3uZ+959m+/+/K8z+VtyuWoSo9JWq35cx7wDdt/bXsusDql93SlptyE309Hw4B9fw3gA832fSQdIWnHOjVrv072klYBPgxcZPtF2zOB14Fzm9uz74+e14EfNp87z1MOMD0kacvK9ZoIXqc0rB8DkLSTpD0lbdxcz34/SppRGpMov3cebjavA8yU9PF6NWu35rMe4A1gGrAL8CSwraQNmzL5nTkKOsNfJS1PGSXwI9uP2z4XeKHpwW7V505rnshQSdpI0rXAdEn7dRoSlJ67jhOAAyVtaNt54/XGwOyBRbafkLS6pNOArwOfAG6U9BHbi5J97wyy76/R3PS4pBOAkyhHtq6TtEe1irZQV/ZXSNrf9qvAm8ChktZo5r7cS/ncmZx9v3eauV0XS1oZwPZ84K6uIh8FPgb8qkL1Wm2Q7N8E7gAs6XnKQdQ9gLslbZb9vre687f9TtNL8SywnqR7gLOBl4GfSdoj2feOpI0lzQAulXQAsJrtp2zPA+6k9B6l924USNpE0lXABZKm2H6bchC7+8D114HDJK3bpt67CXmeu6Z1/mPgfuCXwD7AfOAsSm/dwbYfbcqeT3kz/mWl6rbKINnvSWncHdN8oWxr+4Gm7PnAhrY/W63CLTNI/nsDLwGnANdTjuYeY3uOpL8C9rG9f636tskg2e8L/IYyFPBiYAVgc8qXzYHAq7ZPqVPbdpH0KeAfgCnAd2yfKUndP6Yk/QHwd7Yz766HBsu+2T6J8qN2a9t/32w7Hdje9t616ts275P/asBlwLG2n28+8/ezvW+1CreIpMOAbwMXUHrsdgTusT2jq8xXKAezr7T98yoVbaHmQNJPKHNKXwO2oRw4/Q/gcWDjpoHd+a250PaplarbcxO1525t4LfAmc1Y/+9SjhpuTBl/e7LeXT3tFuDXVWrZTgOz/x4wRdIBLh7oKns9MLfpSo/eGJj/GZQfWFOAC4E1gY2aspcAK6vlq0r10cDsT6c0rre3/eeUz6Fdbd8DPAd0DjDlKPrIzafMqd4EOELS+oMcJd8a+G8oP7gyPLNnBmY/GRbPcZnVadg1/gV4VVlFsJcGzR8wpRfjGaAzZPCHwCpqFvmIEfsNcKLtabYvBxbQZN31u+ZWymu0g8qCWrvUqWrrbAi8Yvsc2xdQ9u0DgZUpw2Iv7Sr7BPC/0J7v2wnZuLP9DOXH7B5d16cB32t2gleAqZKOpAxXWFCrrm2zlOyP6y4naQql4fdI05UePbCE/H8ATLX9U+Bm4CBJx1CGrM2m9OzFCC0h+4uAU5vrj9qe18x1PAB4odk+8YZX9Jjt/wKesv0UcBulYT1wjsXuwO9Luh44lDIvLEZokOynQvkRZXtxxpI+CfwTcF/39hiZJeXffK48Tzmo/RVJh1MaGrOBhXVq2y7Nd+pPuxpyr1PmN9L5XWP7fyiN7DOAg8nvzZ5oRt9N7mosPwzcDnyTsojZmpJOlfQF4EhK715rvm9b3biTtKbKqlyd6+p6k51FGYrWcQPwkqStKHPtZgKfAc6xfWG/6twWQ8z+x8BzknaWtJrKkvyXABfYnta/WrfHEPO/EfitpO0oQwT/GVifssjHt7Jq49AMMfubgGcl7SJpkqSvAlcAF9u+vX+1bofBsu+6+Y3m328CO0nafcAci3WBHYCrbe9m+4nRr3F7DCN7N+U+IOlEykGmi2xnxdJhGGr+AM1n+0nAXOAgyufOCTmgOjRLy972G115bgQ8NOC+21FWbjzG9ladKUGxbCSt1TXSrvN922nbXMK7K6+/TJnjuBJlTYGvUlbFPxI4z/aVfa34KGtt407Sd4BZlEmsp3U2d73JZgBvSuos//tbylGVt5tV6262fbDtq/pd9/FumNm/CbzYvAH/zfa2tq/tc9VbYZj5vwa8ZnuR7ftsH2/76n7Xfbwbwb6/oGlo3GJ7k3zuDN2Ssu/cbtuSlms+Yy4E/qa53yHNj7GzbW9m+7o+V33cG0n2lO/dG5ofttf0t+btMML8n7T9A9v72f7XPld93Hu/7Jsyk1RWy1wFmNU0QPZSOeXNbNtr5zN/6CSdQplHd5Gks5rNk7oO2v0nZWrJl5rrcykH8Za3/YTtGbb3bGP2rZvL1LyBpgLrAZ+mLPE+W9J0l0Ui1MztWqSyMuB1kuZQusU3A1qzWk6/jTD7zTuP08w5iiHqQf7Z94epB9kbFg/RiSFY1uyb4osAbJ+vMiRnIXAdpXFxV/9rP771KPsb00s6PD3I/1rgpgHlYhkMJfvmc3+Npsx+lEWzbqOsDpvsh0hldfuplNWNd6Z0VD0t6RzbCyRNag5UPyXpEmCapEcoPacrNpdWa91qmZJWpKxIdG9nOJmkyyjnr7u8q9yk5g33OcoqOrsBJ9m+t0a92yDZ15X860n29Sxr9l3l16AMjd0LOMr2rH7Wt02SfV3Jv55hZP9ZyjD86yhTTnIQe5iaYZcfsv1cc/3TwNeAM2w/1lVOTa/1UcCmwE6UlWHbv9/bHtcXytjZSymrzHW2rdr8K0oL/U5gqwH3U+26j/dLsk/+E/WS7Mdf9l1lJwFb1n4e4/GS7JP/RL30IPtVga/Vfh7j8bKE7DudU3sCc4DzKKcZOgRYrrltUlf55Wo/j35exvWwTEnrA+cDuwCLJD1ie4HtV5oik4C3KHNanum+r5tXO4Yn2deV/OtJ9vWMJPsOl/kYD/ejvm2S7OtK/vWMNPtmxMYrlAU+YgiWkn3nu/TnwMdcRsTsB5xG6R19x10LZnmCLQw33hdU+T/gTGADyup+u6traevmxdwAeMv2C5L+WNLBdaraOsm+ruRfT7KvJ9nXk+zrSv71jCh7v3dV3hia98t+fidf2zOb8h+pUdGxZNw07qTfPbGg7fnAY7ZfAq6mdMcOfFF3p6yWMwM4kXJelxiCZF9X8q8n2deT7OtJ9nUl/3qSfT3Dyb7T0JO0qco5Sn8NPNufGo9d46JxJ2mF7uFM3TuA7c6JB2dQVoP6U733xLRrUVaju9f2Ds6KaEOS7OtK/vUk+3qSfT3Jvq7kX0+yr2cE2a8k6TDgGuAO24fbfrOPVR+TxvxqmZKOppxc825gtu2bm+2Lz2Whcv6WdyTtCvwtcBywK3Az8EFgbmfniGWX7OtK/vUk+3qSfT3Jvq7kX0+yr2eE2c8E3gZeSfbvGrM9d5LWbLq39wK+DcwDviRpA3h3DLOkLZvxzti+m3LeqF8Afwas4HKiwrzgQ5Ds60r+9ST7epJ9Pcm+ruRfT7Kvp0fZL2d7XrJ/r7G8WuZCypnnL7NtSc9Tzgu1CoCkDwPnABtI+iIwnzIWd0PgL2zfWKfarZDs60r+9ST7epJ9Pcm+ruRfT7KvJ9mPkjHTcydpeUnHS/ooLF596EddY3DnAB+nLDULsAVwn+2dbT9r+w3KeNv184IPTbKvK/nXk+zrSfb1JPu6kn89yb6eZN8/Y2LOnaQtgCsoK+DcYfuQQcpsCpxne99Bblve9tujX9P2SfZ1Jf96kn09yb6eZF9X8q8n2deT7PtrrPTczQO+T2mxT5a0J5QJlNLiFXPWBl5otu8gabfmb+UFH5FkX1fyryfZ15Ps60n2dSX/epJ9Pcm+j8ZE4872c8A1tl8EpgMnNdvfATov+h8CK0o6F/jHrvvW73ocx5J9Xcm/nmRfT7KvJ9nXlfzrSfb1JPv+GhONO3j3PBbADOB1Scc22xc1rfpdgD8CFtj+pO07K1W1dZJ9Xcm/nmRfT7KvJ9nXlfzrSfb1JPv+GRNz7gaStBdwuu0dVJZAfVjSAcCDtufWrl+bJfu6kn89yb6eZF9Psq8r+deT7OtJ9qNrTDbuACTdAuwG3E5Z8nRe5SpNGMm+ruRfT7KvJ9nXk+zrSv71JPt6kv3oGTPDMjskTZJ0BrApcLTtffOC90eyryv515Ps60n29ST7upJ/Pcm+nmQ/+sZkz52kfShLpb5Ruy4TTbKvK/nXk+zrSfb1JPu6kn89yb6eZD+6xmTjLiIiIiIiIoZmzA3LjIiIiIiIiKFL4y4iIiIiIqIF0riLiIiIiIhogTTuIiIiIiIiWiCNu4iIiIiIiBZI4y4iIiIiIqIF0riLiIhxQdI3JK0yjPsdLmmdoTy2pJ9I+uBw6tlrw33eEREx8eQ8dxERMS5ImgNMsT1vCPdZDrgdON72A7187H4Zy3WLiIixJT13EREx5khaVdJMSb+U9KikU4F1gDsl3dmUmSbpAUmPSZradd85ks6W9AvgEGAKcJWkhyStPMj/dewgjz1H0lqSJkt6XNJ0SU9IukrSZyTNkvSkpO276nu5pPslPSjpc0t5bodLuknSXc1jnLqE5/zFweoWERGxJMvXrkBERMQg9gaetb0fgKQ1gCOA3bp6sE62vaDTOydpS9sPN7fNt71Nc98jWUrPne3vSzpuwGN32wg4CPgyMBs4FPgUcABwEvB54GTgDttfboZz3i/pZ7ZfWcLz2x7YHHgVmC1pJrD+wOdse+H71C0iImKx9NxFRMRY9AiwR9MDt7PthYOU+ULTO/cgsBnwia7brulhXZ62/YjtRcBjwO0ucxoeASY3ZfYEviXpIeAu4PeA9ZbymLfZnm/7NeDfKY3FZXnOERERS5Seu4iIGHNsPyFpG2Bf4HIHQ6AAAAFZSURBVAxJt3ffLmkD4HhgO9svSppOaVB1LKnHbDje6Pp7Udf1Rbz7PSrgT2z/ahkfc+CEdw/2nG2fPtxKR0TExJOeu4iIGHOa1S1ftX0lcC6wDfAysFpTZHVKA26hpA8B+yzl4brvN5IyS3MrcIwkAUja+n3K7yFpzWYO4OeBWUt4zr2oW0RETBDpuYuIiLFoC+BcSYuAt4CjgB2BWyQ9a3s3SQ8CjwNzgVlLeazpwMWSXgN2bIZCDnRp92MPo77fBc4HHpY0CXga2H8p5e8HrgfWBa60/YCkvfjd59yLukVExASRUyFERET0kaTDKac2OLp2XSIiol0yLDMiIiIiIqIF0nMXEREThqQbgA0GbD7R9q2j8H/tBZw9YPPTtg/s9f8VEREBadxFRERERES0QoZlRkREREREtEAadxERERERES2Qxl1EREREREQLpHEXERERERHRAv8PsjPQX1M2mbIAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1080x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_jam_w_time.groupby(['start_time_pst']).size().loc[datetime(2017,12,12,0,0,0):datetime(2017,12,13,0,0,0)].plot(figsize=(15, 6))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Delay Outliers in a time window"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 685,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# df_group_frequency = df_jam_w_datafiles.groupby([''])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 686,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datetime import datetime, timedelta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check a time window on a Friday afternoon"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 687,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_time_index = df_jam_w_time.set_index('start_time_pst', drop=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 688,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_jam_time_index.sort_index(inplace=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 689,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_window_start = datetime(2017, 12, 15, 17,0,0, tzinfo=timezone('US/Pacific'))\n",
+    "time_window_end = datetime(2017, 12, 15, 18,0,0, tzinfo=timezone('US/Pacific'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 690,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAA4IAAAFsCAYAAACZ2Ae6AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4wLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvqOYd8AAAIABJREFUeJzs3Xl8lPW1+PHPdyaTfSMbSUhCyEICQRaBAFFAQEUtLt1cSlu31tpql9vb9vb+etveW2/vbW8XbauttdXaulStra1YFUEgCGFHCGuWSUJWyCQh+zLJzPf3RxKMYcsyM89Mct6vV16GZ5555iCQmfN8z/ccpbVGCCGEEEIIIcTkYTI6ACGEEEIIIYQQniWJoBBCCCGEEEJMMpIICiGEEEIIIcQkI4mgEEIIIYQQQkwykggKIYQQQgghxCQjiaAQQgghhBBCTDKSCAohhBBCCCHEJCOJoBBCCCGEEEJMMpIICiGEEEIIIcQk42d0AK4UExOjU1NTjQ5DCCGEEEIIIQxx4MCBBq117OXOm1CJYGpqKvv37zc6DCGEEEIIIYQwhFLq1EjOk9JQIYQQQgghhJhkJBEUQgghhBBCiElGEkEhhBBCCCGEmGQkERRCCCGEEEKISUYSQSGEEEIIIYSYZCQRFEIIIYQQQohJRhJBIYQQQgghhJhkXJ4IKqWeUUrVK6WODjn2iFKqUCl1SCn1jlIqceD4NUqploHjh5RS3xvynBuUUkVKqVKl1LddHacQQgghhBBCTFbuWBF8Frhh2LGfaK3naq3nA28A3xvy2Hta6/kDXz8AUEqZgSeAG4HZwF1KqdluiFUIIYQQQgghJh2XJ4Ja6+1A07BjrUN+GQLoy1wmFyjVWpdpre3AS8CtLg1UCCGEEEIIISYpj+0RVEr9UClVBaznwyuCy5RSh5VSbymlcgaOTQOqhpxTPXDsQtd9QCm1Xym132azuSV2IYQQQvimlq5etL7c/WchhJh8PJYIaq2/o7VOBl4AHh44fBCYrrWeB/wK+PsYrvuU1nqR1npRbGys6wIWQgghhE+raOhg6f+8y8N/fp8+h9PocIQQwqsY0TX0BeDj0F8yqrVuH/j+TcCilIoBaoDkIc9JGjgmhBBCCDEiP99UTK/DyT8L6/jay4ckGRRCiCH8PPEiSqlMrXXJwC9vBU4OHI8HzmittVIql/7EtBFoBjKVUjPoTwDvBD7liViFEEII4fuO1bbw+uFaHlqVTnighf996yRKKR69fR5+ZpmeJYQQLk8ElVJ/Bq4BYpRS1cD3gZuUUlmAEzgFPDhw+ieALyql+oAu4E7dX8jfp5R6GNgImIFntNbHXB2rEEIIISamn2wsIiLIwgMr0okIsqCBH711EgX8XJJBIYRwfSKotb7rAoefvsi5jwOPX+SxN4E3XRiaEEIIISaB3WWNbCuy8e83ZhMRZAHgwZXpOLXm/94uwqTgZ7fPx2xSBkcqhBDG8UhpqBBCCCGEJ2it+b+3TzI1PIC781I/9NiXrslA6/7VQqUUP/3kPEkGhRCTliSCQgghhJgwNp+o52BlM//z0SsItJjPe/yhVRlorfnpO8Uo4CeSDAohJilJBIUQQggxITicmp9uLGJGTAifXJR00fMeXp2JU/d3FVVK8X+fmCvJoBBi0pFEUAghhBATwj8O1VB0po3HP7UAy2WawXxlTSZaw6ObizEp+PHH52KSZFAIMYlIIiiEEEIIn9fT5+Dnm4qZMy2cm+YkjOg5X702E6fW/OLdEpSCH31MkkEhxOQhiaAQQgghfN6f91RSfbaL//noFaNK5r52bSZaa365pRSTUqN+vhBC+CpJBIUQQgjh09p7+vjVllKWpUWzPDNmVM9VSvEv181EA7/aUopS8MPbJBkUQkx8kggKIYQQwqc9s6Ocxg4737ohC6VGn8Appfj6dTNxas0TW62A4oe3zZFkUAgxoUkiKIQQQgif1dRh56ntZazNmcqClCljvo5Sim9cn4VTw2+2WTEpeORWSQaFEBOXJIJCCCGE8Fm/3lpKp72Pb1yfNe5rKaX41tostIYn862ogWRwLKuMQgjh7SQRFEIIIYRPqm3u4k+7T/GxK5PInBrmkmsqpfi3G7LQWvPb7WWYlOK/bsmRZFAIMeFIIiiEEEIIn/SLzSWg+zt/upJSim/fmI0GntpehgL+U5JBIcQEI4mgEEIIIXxOaX07fzlQxT15M0iaEuzy6yul+Pcbs3E6Nb/fUY5Siu/fPFuSQSHEhCGJoBBCCCF8zs/eKSLIYuahVeluew2lFN/5yCycGp7ZWY5S8L11kgwKISYGSQSFEEII4VMOVzXz1tHTfO3aTKJDA9z6WkopvrtuFhrNH3ZWYFKK//jILEkGhRA+TxJBIYQQQviU/9t4kqgQfz63PM0jr6eU4nvrZqM1PL2jHAV8R5JBIYSPk0RQCCGEED5jR0kDO0sb+d662YQGeO5jzOAeQa379wyaTP17CCUZFEL4KpPRAQghhJi8qpo6uekX73GqscPoUMatu9dBVVOn0WFMaFprfvz2SaZFBrF+aYrHX18pxX/eksNnlk7nqe1l/Ojtk2itPR6HEEK4giSCQgghDPPmkTqO17Xy9tHTRocybr/aUsL1j26ntbvX6FAmrLeOnuZITQtfuzaTAD+zITEopfjBrTl8emkKv80v48dvF0kyKITwSZIICiGEMEx+sQ2AAmujwZGMX36xja5eB1tP1hsdyoTU53Dy03eKyIwL5WNXJhkai1KKH9wyh/VLUngy38pPNkoyKITwPZIICiGEMERHTx/7KprwMyn2VTTR63AaHdKYNXfaOVbbCsA7x84YHM3E9NeD1ZTZOvjG2izMJuP35ZlMikduncNduSn8epuVx7eUGh2SEEKMiiSCQgghDLHL2kivQ3NnbjKddgeF1c1GhzRmu8ua0Bqy48PYWlRPd6/D6JAmlO5eB49tLmF+ciTXz55qdDjnmEyKH942h3VzE/jVllLqWrqMDkkIIUZMEkEhhBCGyC+2Eexv5surMwEoKPXd8tACawPB/ma+uTaLTruDHSUNRoc0oTy36xR1Ld382w3e16XTZFL82w3ZOLXmqe1lRocjhBAj5vJEUCn1jFKqXil1dMixR5RShUqpQ0qpd5RSiQPHlVLql0qp0oHHrxzynLuVUiUDX3e7Ok4hhBDGyi+2kZcezdTwQGYlhLOrzJcTwUYWp0axPDOWsEA/Nh7z/eY33qK1u5cntpWyYmYsy9KjjQ7ngpKjgvnogmn8eW8ltrYeo8MRQogRcceK4LPADcOO/URrPVdrPR94A/jewPEbgcyBrweA3wAopaKA7wNLgFzg+0qpKW6IVQghhAEqGjqobOpk5cxYAPLSo9l/6qxPllTWt3ZTWt9OXno0/n4m1mTHsfnEGfp8eM+jN/nd9jKaO3v51toso0O5pC9ek469z8nTO8qNDkUIIUbE5Ymg1no70DTsWOuQX4YAg621bgX+pPvtBiKVUgnAWmCT1rpJa30W2MT5yaUQQggfNdgtdOXMOACWpUVj73NysPKskWGNyeBKZl56DABrc+I529nL3oqmSz1NjICtrYffv1fOurkJzJkWYXQ4l5QWG8q6uYk8t6uC5k670eEIIcRleWyPoFLqh0qpKmA9H6wITgOqhpxWPXDsYseFEEJMAPnFNmbEhJASHQxAbloUJgW7fXCMREFpI+GBfsxODAdgZVYsAX4m6R7qAo9vKcHucPKv13v3auCgh1Zl0GF38IedFUaHIoQQl+WxRFBr/R2tdTLwAvCwq66rlHpAKbVfKbXfZrO56rJCCCHcpLvXwS5r47myUIDwQAtXJEX65DzBgrIGlqZFnxtpEOzvx4qZsWw8dlpmy41DVVMnL+6t5I7FycyICTE6nBHJig9jbc5U/rCznLbuXqPDEUKISzKia+gLwMcHvq8Bkoc8ljRw7GLHz6O1fkprvUhrvSg2NvZCpwghhPAi+yvO0tXrYMXMmA8dX5YWzaGqZjp6+gyKbPSqmjqpauoib1gTk7U58dS1dFNY3WJQZL7v0U3FmJTiKwNdZX3Fw6syae3u47ndp4wORQghLskjiaBSauhP8VuBkwPfvw58dqB76FKgRWtdB2wErldKTRloEnP9wDEhhBA+Lr+4Hn+ziaVpH06e8tKj6XNq9p/ynX2CBdb+MRFXZXw4qb12Vhxmk5LuoWN08nQrrx2q4Z6rUomPCDQ6nFG5IimCa7Ji+f175XTafeemhhBi8nHH+Ig/A7uALKVUtVLqfuBHSqmjSqlC+pO6rw6c/iZQBpQCvwO+BKC1bgIeAfYNfP1g4JgQQggfl19sI3dGFMH+fh86vih1ChazOpdc+YICayMxoQFkxIV+6HhksD9L06IkERyjn24sIjTAjy+uTDc6lDH58uoMmjrs/Hlv1eVPFkIIg/hd/pTR0VrfdYHDT1/kXA08dJHHngGecWFoQgghDFbb3EXxmXY+uTD5vMeC/f2YnxzJLh/ZJ6i1psDaSF569AWHnK/Nied7/zhGaX0bGXFhBkTom/ZXNLH5RD3fXJtFZLC/0eGMycLpUSxLi+ap7VbWL0kh0GI2OiQhhDiPEXsEhRBCTFLbB8dGZF14T/ey9BiO1rTQ0uX9jTastnZsbT3n7Q8cdP3seAA2SvfQEdNa8+O3TxIbFsC9V6UaHc64fHl1Bmdae3j1QLXRoQghxAVJIiiEEMJjtpfYSIgIJHNYKeWgvPRonBr2lnv/boDBDqeD8wOHi48IZH5ypJSHjsK2Ihv7Ks7ylTWZ55UO+5pl6dFcmRLJb7ZZ6XU4jQ5HCCHOI4mgEEIIj+hzOHmvpIGVM2MvWEoJsCAlkgA/k0/sEywobWRaZBDJUUEXPWdtTjyF1S3UNHd5MDLf5HT2rwZOjw7mzsXnlw77GqUUX16dSU1zF39//4KNz4UQwlCSCAohhPCIQ1XNtHX3fWh+4HABfmYWpU7x+n2CTqdmV9nF9wcOWpszFYB3ZFXwsjYU1nLydBtfv24mFvPE+HhyTVYsOYnh/HqbFYdTZkoKIbzLxPhJK4QQwuvlF9swmxR5GRcupRyUlx7DydNtNLb3eCiy0Tte10pLV+95YyOGS4sNZebUUCkPvQx7n5OfvVPMrIRwbp6baHQ4LtO/KphBeUMH/zxSZ3Q4QgjxIZIICiGE8Ij8YhsLkiOJCLJc8rxlA81Xdpd57z7BwdLVZRdpFDPU2px49pY30dRhd3dYPuvl/VVUNnXyrbVZmEwXX2H1RdfPjiczLpQntpTilFVBIYQXkURQCCGE2zW091BY3XLJstBBV0yLIMTf7NX7BAusjaTHhjA1/PLDztfmxOPUsPm4dA+9kE57H798t4Tc1CiuuUg3WV9mMikeXp1B0Zk2Np2QvwNCCO8hiaAQQgi321HSn9RdbGzEUBazidwZUewq8859gr0OJ3vLmy7aLXS4nMRwpkUGSXnoRfxhZwW2th6+dUPWJfdb+rKPXJFAanQwj28ppX+EshBCGE8SQSGEEG6XX2wjKsSfOYkRIzo/Lz2GMlsHp1u63RzZ6BVWN9Npd1x0fuBwSinW5sTzXmkD7T19bo7OtzR32nky38q1s+JYlBpldDhu42c28aVrMjhS00L+wCxNIYQwmiSCQggh3Mrp1LxXYmNFZsyI938N7r3bVeZ95aEFpf0rlUvTRpYIQn/3UHufk21F9e4Kyyf9Jt9Ke08f31ibZXQobnfbgmlMiwziV7IqKITwEpIICiGEcKvjda00tNtHVBY6aFZCOBFBFq8cI1FgbWR2QjhTQvxH/JxFqVFEh/iz8ZjsERt0uqWbZ3dW8NH508iODzc6HLfz9zPx4Mo0Dpw669WNkIQQk4ckgkL4MK21dKETXm+wFG555sgTQbNJsTQtigIvSwS7ex0cqDw74rLQQWaT4rrZU9l6sp6ePoebovMdXXYHX3rhABr4l+tmGh2Ox3xyUTKxYQE8vrXE6FCEEEISQSF82QPPHeAbfzlsdBhCXFJ+kY0508KJCQ0Y1fPy0mOoPttFVVOnmyIbvQOnzmLvc152fuCFrM2Jp72n71xp6WTV53Dy8IsHOVTVzC/vnE9yVLDRIXlMoMXMF1aksbO0kQOnzhodjhBikpNEUAgfpbVmb3kTbx09TXevrDAI79Ta3cuByrMjGhsx3Ll9gl60KlhgbcBsUiyeMfrGJnkZ0YQG+E3q7qFaa/7fa0d492Q9P7h1DjfMSTA6JI/71JIUpgRbeGJrqdGhCCEmOUkEhfBRjR12Wrp66ep1sNtL2+wLUVDagMOpWTkzbtTPzYwLJSbU36vmCRZYG5mXFEFogN+onxvgZ2ZVdhybjp/BMUlLun++qZhX9lfzldUZfHrpdKPDMUSwvx+fW57GlpP1HK1pMTocIcQYaK35xeYSjte2Gh3KuEgiKISPsta3n/t+y0npRCi8U36xjbAAPxakRI76uUoplqXHUGBt9Ioui23dvRRWt4x4fuCFrM2ZSmOHfVKWBT63q4JfbSnlrtzkSbUv8EI+s2w6YYF+sioohI8qOtPGo5uLOVDp2z/LJREUwkdZbR0AZMeHseVkvVd8UBZiKK01+UU2rsqIwWIe29vNsrRo6tt6KGvocHF0o7evogmHU4+6UcxQ12TF4e9n4u2jk6s89M0jdXzv9WNcO2sqj9w6Z8IOjh+p8EAL9+al8tbR0xSfaTM6HCHEKG04XIvZpLhxTrzRoYyLJIJC+CirrZ1Ai4n1S6dTfbaL0iErhEJ4g9L6dmpbukc1NmK4waTLG7qHFpQ24u9n4srpU8Z8jdAAP5ZnxLDx2OlJc/Nml7WRr710iCtTpvCruxbgN8abAhPNvVfNINjfzK9lVVAIn6K1ZsPhOvLSo0fdBM3byE9jIXxUaX07aTGhrMnu33sl5aHC2wyOjVgxhkYxg6ZHB5MYEcguL9gnWGBtZGHKFAIt5nFdZ21OPDXNXRzz8b0lI3GirpUH/rSf6dHBPH33IoL8x/f/biKZEuLPZ5ZO5/XDtVR4wYq3EGJkCqtbqGzq5Oa5iUaHMm6SCArho6y2djLiQkmMDGJWQrgkgsLr5BfbyIwLZVpk0JivoZRiaXo0u6yNhs7MbOqwc7yudVxloYPWzIrDpJjw3UOrmjq5+5m9hAb68cf7cokM9jc6JK9z//IZWMwmfrPNanQoQogReqOwFotZsTbHt8tCQRJBIXxSl91BTXMX6bGhAKzOjmX/qbO0dPUaHJkQ/brsDvaUN41rNXBQXnoMZzt7KTJwL9VgZ968McwPHC46NIDcGVETOhFs6rBz9zN76e518Mf7ckkcx82AiSwuLJC7clP468Fqapq7jA5HCHEZTqfmjcI6Vs6MJSLYYnQ44yaJoBA+qLyhA60hPS4EgNXZcTicmu0DpXhCGG13eSP2PueY5gcOt8wL9gkWWBsI8TczNynCJddbmxNP8Zl2ymwTb29vp72P+57dR01zF0/fs5iZU8OMDsmrPbAiDaXgt/myKiiEtztQeZa6lm5unuf7ZaEgiaAQPsk68OFxcEVwfvIUpgRb2CrlocJL5BfZCLSYyB3D4PXhpkUGkRodbOg+wQJrI7kzosbc/XS46wdKijYeO+OS63mLXoeTh144SGF1M7+6awGLU8f/5z/RJUYG8YmFSby0r4r61m6jwxFCXMKGw7UEWkxcO2uq0aG4hCSCQvggq60dpWBGTP+KoNmkWDkzlm3Ftkk7qFp4l+3FNpamRY+7scqgZenR7Clros/hdMn1RuN0Szdlto5xzQ8cblpkEFdMi5hQ5aFaa7791yNsLbLx37ddcS7ZFZf3xZUZOJya371XZnQowgv9ZX8Vtz6xE3uf53/+iQ/0OZy8eaSO1dlxhAT4GR2OS7g0EVRKPaOUqldKHR1y7CdKqZNKqUKl1GtKqciB46lKqS6l1KGBryeHPGehUuqIUqpUKfVLNdkHDgkxjNXWQdKUoA99yF6VHUdTh53D1c0GRiYEVDZ2UtbQ4ZKy0EHL0mNo6+kzpNPmrrKGgRjG3yhmqBvmxHOoqpnTLRNjFej/Nhbx14PVfO3aTD61JMXocHxKSnQwt85L5PndlTR12I0OR3gRrTW/ybdyuKqZd45PnBtHvmhPeRMN7fYJ0S10kKtXBJ8Fbhh2bBMwR2s9FygG/n3IY1at9fyBrweHHP8N8Hkgc+Br+DWFmNRK69vPlYUOWjkzFrNJSXmoMFx+Sf9eVZcmgmnG7RMsKG0kIsjC7IRwl153bU5/adGmCfDh7g87y/nNNiufWpLCV9dkGh2OT/rSqnS6+xw8s6PckNfXWvPPwjpW/mQrz+40JgZxvgOnzlJm68Ck4IXdlUaHM6ltOFxLiL+ZVQNjuyYClyaCWuvtQNOwY+9orfsGfrkbSLrUNZRSCUC41nq37p+2+yfgNlfGKYQvczo1ZbZ2MoYlgpHB/ixMmSJjJIThthfbSI4KOle67AqxYQFkxoWyq8yziaDWmgJrI8vSojGZXFuckhEXRlpsCG/7eHnoG4W1/OCN46zNmcojt85BinjGJiMujJvmJPDHggqPd4CubOzk3mf38dCLB6lt7uKXW0rp7nV4NAZxYS/vqyLE38yXrslgV1kjpfUTr8GUL7D3OXnr6Gmuz4l32ZYHb+DpPYL3AW8N+fUMpdT7Sql8pdTygWPTgOoh51QPHBNCADXNXfT0OUmPCz3vsVXZcRyrbZ0wpWbC99j7nBSUNrByZqzLE4K89Gj2lTd5dJ9MZVMnNc1dXJXh2rLQQTfkxLO7rInmTt8sBywobeDrLx9m8fQofnHnAswuTpYnm4dWZdDW08efCio88nr2PidPbC3lukfz2VfexPfWzeaP9+bS1GHnLweqL38B4VZt3b28UVjHurmJ3HNVKhaz4sU9sipohB2lNlq6elk3N8HoUFzKY4mgUuo7QB/wwsChOiBFa70A+DrwolJq1HU3SqkHlFL7lVL7bTZpnS8mvuEdQ4daPVCusLVIVgWFMQ6cOkuH3cGKTNeVhQ5alh5DV6/Do/tgB0tRl7mwUcxQa3PicTg1757wvX+zx2pbeOC5A8yICeF3n100oe6SG2V2YjjXzorj6Z3ldPT0Xf4J47C3vImP/PI9frKxiNXZcWz+15Xcd/UMlqVHMz85kt9tL5PmYwZ7o7COrl4Hd+QmExMawA1zEnj1QBVddlmt9bQ3DtcRHujHcje8txnJI4mgUuoeYB2wfqDcE611j9a6ceD7A4AVmAnU8OHy0aSBYxektX5Ka71Ia70oNnZi/eEIcSFWWwcA6bHnl93NnBrKtMggKQ8VhskvtuFnUi4ZvD7c0rQolIJdHtwnWGBtJC4s4IL/3lxhblIECRGBPlceWtXUyT1/2Ed4oB/P3rd4QgxW9hYPrcqgubOXF/accsv1mzrsfPMvh7n9t7votDt45p5F/ObTC0mICAJAKcWDK9OobOrk7aO+9fdyonl5XxWZcaEsSI4EYP2SFFq7+3ijsNbgyCaX7l4H7xw/w41zEvD3m1gDF9z+u1FK3QB8C7hFa9055HisUso88H0a/U1hyrTWdUCrUmrpQLfQzwL/cHecQvgKq62dyGALUSH+5z2mlGJVdiw7Sxvo6ZM7hsLz8ottLEqdQqgbWmtHBvszOyGcAg/NE9Ras8vaQF56tNv2vSmlWJsTz/ZiG512964AuUpjew+ffWYv9j4nf7o/91wCIVxjQcoUlmfG8NT2cpfu09Na88r+Ktb8bBuvvV/DgyvT2fT1FazOPn8e2nWz45kRE8KT+VYG7t8LDys+08ahqmbuWJx87ufPkhlRZMSF8oKUh3rUtqJ62nv6JswQ+aFcPT7iz8AuIEspVa2Uuh94HAgDNg0bE7ECKFRKHQJeBR7UWg82mvkS8HuglP6VwqH7CoWY1AY7hl7sg+nq7Dg67Q72lDVd8HEh3OVMazcn6lpZOdN9HdXy0qM5eKrZI40sSurbaWi3u3R+4IVcnzOVnj4n24u9f3tDR08f9z27j7qWLp65ZxEZcWFGhzQhPbwqg4b2Hl7eV+WS65WcaeOOp3bzrVcLSY8N5Y2vXM23b8wm2P/CN2zMJsXnl6dxpKbFoyvw4gMv76vCYlZ8dMEHbTKUUqxfksKhqmaO1rQYGN3ksuFwHTGh/ixNizI6FJdzddfQu7TWCVpri9Y6SWv9tNY6Q2udPHxMhNb6r1rrnIFjV2qtNwy5zn6t9RytdbrW+mEtt6OEOOdCHUOHykuPIdBikvJQ4XGDiYwrx0YMl5ceg93h5OCps257jUEFpe6ZHzhcbmoUU4ItXl+G1+tw8sUXDnK0tpXH77qShdMn3ocib7EkLZrc1CiezLeOqzlSl93BTzae5KZfvkfR6TZ+9LEreOULy8iOv3xLho9dOY2Y0ACe3C5D7j2tp8/Ba+/XcO2sqUSHBnzosY9dmUSgxSSrgh7S0dPHuyf7y0L9zBOrLBQ83zVUCDEOzZ12GtrtpMddfL9SoMVMXnoMW07WS0mP8Kj8YhuxYQHMSnDfKtHiGVGYTcoj8wQLrI0kRwWRHBXs1tfxM5u4dtZU3j1Z79GOqKPhdGr+7dVCthfb+J+PzuHa2eeXEwrXenh1BnUt3fzt4Ni6d24rquf6x/J5YquVm+clsuVfV3JnbsqIx6AEWszce1Uq24ttHK9tHVMMYmw2H6+nqcPOHYuTz3ssIsjCLfMS+cehGtq6PTtmZDLafOIM3b3OCVkWCpIICuFTPmgUc/EVQegfI1HZ1HnufCHczeHUvFfinrERQ4UG+DE3KcLt+wQdTs3uskby0txbFjpobU48bd197PbwnMSR+vHbJ/nb+zV84/qZ3LE4xehwJoXlmTHMS4rg19us9DlGfoPgTGs3D714kHv+sA+L2cSLn1/Cz2+ff97K0kh8esl0QvzNPLXdOurnirF7eX8ViRGBF+1QuX7JdDrtDv7+/kV7KQoX2XC4jvjwQBZNn2J0KG4hiaAQPuRSoyOGOjdGQspDhYcUVjfT0tXr1rLQQXnp0RyubqHdje31j9W20NrdR56b5gcOd3VmDMH+Zq/sHvr798r47fYyPrtsOg+tyjA6nElDKcXDqzOpbOpkwwi6RDqcmmd3lrPmZ/lsOn5vhgeoAAAgAElEQVSGf71uJm99dfm49rhGBFu4KzeFDYV1VJ/tvPwTxLjVNHfxXomNTyxMuuhcznnJkVwxLYIX9lRK5Y8btXT2kl9cz7q5CSNeSfc1kggK4UOstnb8zSaSply6S9+0yCCypobJPkHhMfnFNpSCq90wNmK4ZWkxOJyafRXua4j0wfxAzySCgRYz12TFsun4GZxeNLvtH4dq+O9/nuCmK+L5/s05bl3tFedbkx1HdnwYj28pveTfiyPVLdz2xE7+c8NxFqRE8s7XVvDlNZkE+I1/tuN9V89AAU/vKB/3tcTlvbq/Gq3hk4vOLwsdav2SFE6ebuOAB/ZLT1Ybj5+m16EnbFkoSCIohE+x1reTGhM8og3Lq7Lj2FfRRKvsIRAekF9sY15SJFMuMNbE1RZOn4K/2eTWboYF1kYy40KJCwt022sMtzYnHltbD+9XeccHu/dKbHzjL4dZMiOKn98+/6KrE8J9TCbFw6szsNo6Lrha3Nbdy3++foxbn9hBXUs3v7xrAX+6L5fUGNfNvUyMDOKW+Ym8tLeKsx12l11XnM/p7B/xcVVG9GX3Jt8yP5GwAD9pGuNGGw7XkhIVzNykCKNDcRtJBIXwIVZbBxlxly4LHbRmVhx9Ts2OEs/MXBOT19kOO4ermj1SFgoQ5G9mQUqk2/YJ2vuc7CtvIs9Dq4GDVmXHYTErNh4749HXvZCjNS08+NwB0mNDeeqziwi0jH9lSYzNjXMSSIsN4VdbSs+VAWqtefNIHdf+PJ8/7qpg/ZLpvPuvK7llXqJbVm0fWJFGV6+D53e7Z8i9O5ScaeP2J3dRWt9mdCgjttPaQE1z14j24Qb7+/GxK6fxz8I6miRBd7nG9h4KrI2sm5swoSshJBEUwkf09DmobOq87P7AQQuSI4kIskh5qHC7HaUNODWszPJMIgj9JZvHaltp6XT9ivfh6ma6eh0sc/P8wOHCAy3kpcfw9tHThu77sdraufuZvUQG+/PH+3KJCLIYFovon+n30DUZnKhrZcvJeqqaOrn32X186YWDRIcE8Lcv5vHIbXPc+ueUHR/OqqxYni2o8MgMz/HSWvOd146yt6KJn24sNjqcEXt5XxURQRauH2FX3vVLp2N3OHn1gGvmTYoPvHX0NA7nxC4LBUkEhfAZlY2dOJx6xImgn9nEypmxbCuq96o9R2LiyS+2ERFkYV5SpMdeMy89Bq1hd7nry0MLShtRCkOGB98wJ57Kpk5OnjZmFaOqqZNP/34PSimeuz+XqeGeK40VF3fL/ESSo4L47t+Pct2j+ewtb+I/PjKL1x++igUpnulm+IWV6TR22PnLgbGNs/Ckvx2sYW9FE3OmhfP2sdMcq/X+4etnO+y8c+wMH10wbcQr8DOnhpGbGsULeyrlfd7FNhyuJSMulOx4941D8gaSCArhI0baMXSo1dlxNLTbKazx/jdB4Zu01uQX21ieGePRPWTzkyMJtLhnn+BOawM5ieFEBrt/v+Nw186ailKw0YDuofWt3Xz66T102h08d38uaaP4WSPcy2I28eVVmdS2dLNyZiybv76Szy1P8+iA6yUzopiXHMnvtpfh8OKko6Wrl/996wRXpkTy/P1LCAv04xebS4wO67L+fqgGu8PJ7ZdpEjPc+qUpnGrsZKebR+pMJqdbutlb0TThy0JBEkEhfMbgTMC02JE3AVg5MxaTQspDhducqGvD1tbjsf2Bg/z9TCxOjXJ5Ithld/B+5dlxtdwfj9iwABZNn8LbRz2bCJ7tsPPpp/dga+vh2XsXMysh3KOvLy7vk4uS2PFvq/jtZxaRGHnpztHuoJTiwRVpVDZ1evzv52j87J0imjrsPHLbHCKD/bn/6hm8c/wMR734hqjWmpf3VXHFtAhmJ47u394Nc+KJCvHnhd3SNMZV/nmkDq1h3dyJXRYKkggK4TNK69tJiAgkJMBvxM+ZEuLPgpQpMk9QuM32EhuAxxNB6N8nWHSmPxF1lf2nmuh1aI83ihlqbU48J0+3Udnombltbd293P2HvVQ0dvL7uxd5rNRQjI5SiqQpl+4k6W7X58QzIyaEJ/OtXjm/7mhNC8/vPsVnl6WSk9jf6fG+q2cQHujHY168KlhY3cLJ023csXh0q4EAAX5mPrkoiU0nznC6pdsN0U0+bxTWMjshfMTN+XyZJIJC+AirrX1UZaGDVmfHcaSmhfpWeYMQrpdfZGNWQjhxBuwlG1y1213mulXBAmsjfibF4lTP7w8ctDYnHvBMeWiX3cH9f9zP8dpWfrP+SsNWQoVvMJsUn1+expGaFna58N+dKzidmv/4+1GiQgL4+vUzzx0PD7TwueVpbD7hvauCL++vItBi4pb5Y1uB+lRuCg5n/6qiGJ+qpk7er2ye8E1iBkkiKIQP0FpjrW8f092p1dlxAGwrsrk6LDHJtff0sf9UEytmGpM8zEkMJyzAz6UfSAusjcxPjhzVyrurJUcFMzsh/IJz41zJ3ufkwecPsK+iiUfvmM+aWSPrVCgmt49dOY2YUH9+m19mdCgf8vL+Kg5VNfOdj2QTHvjhDqr3XJU6sCrofR1Eu+wONhyq5aY5CefFPVLTo0NYMTOWP++tpM/hdHGEk8sbhXUArJubYHAkniGJoBA+4ExrDx12B+mj2B84KDs+jISIQN49afxsMjGx7LI20uvQhpSFQn9n3NwZrtsn2Nrdy5HqZkPLQgfdMCeeg5VnqW9zz0p+n8PJV196n/xiGz/62BWT5u63GL9Ai5l7r5pBfrGNE3WtRocDQFOHnR+/fZIlM6K4bf608x4PD7Tw+eVpbD5RT2F1swERXtybR+po6+nj9jGUhQ61fkkKp1u7pSfAOG04XMv85EiSo4wtw/YUSQSF8AFj6Rg6SCnFquw4dpQ00NPn/fOfhO/IL64n2N/MounGlVEuS4+mvKGDupaucV9rb1kTTo3H5wdeyNqceLSGTcddfwPH6dR8+29HeOvoab67bvaIhlcLMdSnl0wn2N/MU9u9Y1Xw/94+SXt3H4/cNueiXR7vuSqVyGCL1+0VfHl/FanRwSyZMb6fo2uy44gPD+SFPdI0ZqystnaO17VOqhtjkggK4QPOJYJj3Li8OiuODruDfeVnXRmWmMS01mwrspGXHoO/n3FvJYN72lyxKlhgbSTAz8SCFM/NQ7yYmVNDSY0Odnl3Rq01P3jjOK8eqOZfrp3J/VfPcOn1xeQQEWzhrtwUXj9cS/VZzzQ1upiDlWd5aV8V9109g5lTLz7zLWxgVXDLyXoOVXnHqmCZrZ295U3cvjh53GMK/Mwm7sxNZnuJzWONpiaaNw7XoRR85IrJURYKkggK4ROs9e2EBvgRFxYwpufnZUTj72eSkhHhMuUNHVSf7WJlljFloYOy48OYEmyhwCWJYAOLUqeMeJizOymlWJsTzy5rIy1dvS677s/eKebZggo+v3wGX1mT4bLrisnnvqtnoIBndlQYFoPDqfnu348SHx7IV9dkXvb8u/NSmRJs8Zq9gq/sr8ZsUnziyiSXXO/OxSmYlOLFvbIqOFpaa14/XENuahTxEZ5vfmYUSQSF8AGltnbSY0PGfMcw2N+PZWnRbC2SRFC4Rn7xwNiITGMTQZNJsTQtml3WxnG1s29o7+Hk6Tav6pq5dk48fU7tsvEvv9lm5fGtpdyVm8z/u2nWhB+ULNxrWmQQt8xL5KV9lTR32g2J4fndpzhW28p3180eUYOn0AA/Pr8ijW1FNt6vNLZCps/h5K8Hq1mVFeuyrsvxEYFcOyuOV/ZXyVaQUTp5ug2rrYN1k6gsFCQRFMInWOs7xlwWOmjNrDjKGzoob+hwUVRiMssvtpEWE0JKtPEb6vPSo6lp7qKyaezlUIMjKLyhUcyg+UmRxIUFuGSMxHO7Kvjx2ye5ZV4i/33bFZIECpd4YGUanXYHz+065fHXtrX18NN3ilieGcNNV8SP+HmfXTa4KmjsXsGtRTZsbT3cvmh8TWKGW79kOk0ddpeXlU90Gw7XYjYpbpwz8r9LE4EkgkJ4ufaePk63do+pUcxQq7L6x0hIeagYr+5eB7vLGllhULfQ4Za5YJ9ggbWR0AA/rpgW4aqwxs1kUlyfM5VtRTa6e8d+d/9vB6v57j+Oce2sOH52+zzMJkkChWtkx4dzTVYszxZUjOvv6Fj875sn6Ol18l+35IzqxkZogB8PrEgnv9jGgVPGrQq+vK+K2LAAVg2MeHKVqzNimB4dzAu7pTx0pLTWbCisJS89mpjQsW3B8VWSCArh5crG0TF0qOSoYDLjQtkiYyTEOO2raKK712nY2Ijh0mNDiA0LGNc+wV3WRpbMiMLP7F1vizfkJNDV62B78djmgL599DTffLWQvPRoHv/UlVi87PcnfN8XVqTT2GHn1QPVHnvNPWWN/O39Gh5YkUbaGN4bP7tsOlEh/obtFaxv7WZrUT0fvzLJ5f8mTSbFp3JT2FvRRPGZNpdee6IqrG6hqqlrUnULHSTvCEJ4ucGOoRlxo58hONzq7Dj2ljfR3tM37muJySu/yIa/n4klacaNjRhKKUVeejQFY9wnWNvcRXlDB8u8qCx00JK0KCKCLGw8NvobONuLbXzlz+8zNymC3312kVc0wRETz9K0KOYlRfC798pwOMe+T3ekeh1OvvuPo0yLDOKhVWNreBQS4McXVqTxXkkDB041uTjCy3v1YDUOp+b2Ra5pEjPcJxYm4W828aKMkhiRDYdrsZj7G3RNNpIICuHlrPUdmE2KlKjxJ4KrsuPodWh2lIxtdUEI6N8fuGRGFMH+l2/O4Cl56dE0tPecu3EyGoMlpd7UKGaQxWxiTXYcm0+codfhHPHz9lU08cBz+0mLDeHZe3JH1EhDiLFQSvHgynRONXa6ZD/r5Ty7s4LiM+385y05BPmP/ebGZ5ZNJybUn0c3eXavoNaav+yvJjc1akyrmSMRHRrATVfE89cD1XTa5cbvpTidmjcK61g5M5aIIIvR4XicJIJCeLnS+namRwW7ZFbbwulTCAv0k32CYsxqmrsoqW/3mrLQQcvS+pO4sZSH7rQ2MCXYQnb8xWeQGWntnHhaunrZWz6ylYujNS3c94d9JEYE8dz9S4gInnwfboRnXZ8TT2p0ML/Nt46re+/lnG7p5rHNxazJjuO62VPHda1gfz++sCKdHaUN7Kvw3Krg3vImyhs6uH2xa5vEDLd+6XTaevrYcLjWra/j6/afOsvp1u5JWRYKbkgElVLPKKXqlVJHhxz7iVLqpFKqUCn1mlIqcshj/66UKlVKFSml1g45fsPAsVKl1LddHacQvsJqax93x9BBFrOJFTNj2Vpkw+mBEh4x8QzuVfO2RDA5KohpkUEUlI4uEdRas8vayLL0aExe2kRlRWYsgRbTiFZbSs608Zmn9xAeZOH5zy0hdoyzR4UYDbNJ8fkVaRyubmF3mfuSqkf+eZw+p+Y/b8lxyfXWL00hJtSzewVf3l9FWIDfqDqdjsWi6VPImhrG89I05pLeKKwl0GLi2lnju7Hgq9yxIvgscMOwY5uAOVrruUAx8O8ASqnZwJ1AzsBzfq2UMiulzMATwI3AbOCugXOFmFT6HE4qGjvG3ShmqDXZcdjaejhW2+qya4rJI7/IRmJEIBkuujnhKoP7BHeXN47qJkdFYyd1Ld1eWRY6KMjfzMqZsWw8dvqSv7fKxk4+/fQe/MwmXvjcEhIjgzwYpZjsPn5lEjGh/vx2u9Ut199R0sA/C+t4aFUGyVGuGVsT7O/HgyvT2VnaOOIV9/Fo7e7lzSN13Dw/0e2l9Uop1i9N4UhNC4XVzW59LV/V53Dy5pE61mRPnbTl8y5PBLXW24GmYcfe0VoPFinvBgZ3x94KvKS17tFalwOlQO7AV6nWukxrbQdeGjhXiEml6mwXvQ5Neuz49wcOWjkzFqXgXekeKkap1+FkZ2kDK7NivXIO3bL0aJo7ezlxeuQ3OQqsDYB3zQ+8kBvmxHOmtYfDF/lAd7qlm/VP76anz8nz9y8hNcZ1PzOEGIlAi5l78lLZVmTjRJ1rbzT29Dn43j+OkhodzAMr0lx67fVLphMTGsCjm9y/Kvj6oVq6e53c4eLZgRdz24JpBFnMMkriInaXNdHQbufmeQlGh2IYI/YI3ge8NfD9NKBqyGPVA8cudvw8SqkHlFL7lVL7bTZpgCEmFmv9wOgIF66+RIcGMD85kq2yT1CM0vuVzbT19HldWeigwa6fo5knWGBtJD48kBlenjitzpqKn0ldsHtoY3sPn356D03tdv54by5ZXrrXUUx8n146nWB/M09tL3PpdX//XjllDR38161zXN79NsjfzBevSWdXWSO7y8Y+gmYkXtlfRXZ8GHOTPDOvNDzQwm0LEvnH4Rpauno98pq+ZMPhWkL8zVyT5dpZjr7Eo4mgUuo7QB/wgquuqbV+Smu9SGu9KDbWOz+cCDFWgx0Q02NcW4a3OiuOw9Ut2Np6XHpdMbFtL7ZhNinyMryzjDIhIoi0mJARJ4JOp2a3tZG89GivXOEcKiLYwrL0aDYeO/2hZhyt3b189pm9VDV18vQ9i5mXHHmJqwjhXpHB/ty5OIXXD9dSfbbTJdesaurkV1tKuHFOvNtuQq1fkkJcmHtXBY/XtlJY3cLti5I9+vNm/ZLpdPc6ee2g5+Y8+gJ7n5O3jtZxfU78pB6t47FEUCl1D7AOWK8/eBerAYaujycNHLvYcSEmldL6dmJCA1ze9W9Vdv/dr21FsiooRi6/2MaVKZGEB3pvF8pl6dHsKW+ibwSjForr22jssHvl/MALWZsTT3lDByUDlQKd9j7u+8M+is+08eRnFrI0zTd+H2Jiu3/5DACe2VHhkuv94I3jmJTiu+vc1yoi0NK/KrinvOlcubirvbK/Cn+ziY8uuGCBm9vMmRbBvORInt9T6daOrr5mR6mN1u6+SV0WCh5KBJVSNwDfAm7RWg+9RfQ6cKdSKkApNQPIBPYC+4BMpdQMpZQ//Q1lXvdErEJ4E6ut3SWD5IfLSQxnangAWyURFCPU0N7DkZoWry0LHbQsPZr2nj6O1LRc9tydAx1GfSURvH72VJSCjUdP09Pn4AvPHeBg5Vkeu2MBqyZxaZPwLtMig7hlXiIv7aukudM+rmttOXmGTcfP8JU1mW5vfnRXbv+q4GObS1yeMHX3Onjt/Rquz5nKlBB/l157JNYvSaG0vt0jDXF8xYbDdUQEWbg6w7vf09zNHeMj/gzsArKUUtVKqfuBx4EwYJNS6pBS6kkArfUx4BXgOPA28JDW2jHQWOZhYCNwAnhl4FwhJg2tNVabazuGDlJKsSorjveKG7D3jXxItZi83isZHBvh3QnH4KrYrhHs9dllbWB6dDBJU1zTgdDd4sIDWZAcyZtHT/PlF9/nvZIGfvTxuXxk7uS+oy28zwMr0ui0O3h+96kxX6O718H3Xz9GRlwo9101w4XRXVigxcyXrklnb3nTqPYZj8Q7x8/Q0tXLHW6eHXgxN89NJDzQj+f3SNMY6P+79c6x09yQE++SGc2+zB1dQ+/SWidorS1a6ySt9dNa6wytdbLWev7A14NDzv+h1jpda52ltX5ryPE3tdYzBx77oavjFMLbNXbYaenqdUsiCLA6O462nj72e3CQrvBd+UU2okP8yUkMNzqUS4oJDSA7PuyyH+T6HE72lDV5fbfQ4dbmxHOirpV3jp/h+zfP5nYPdR8UYjRmJYRzTVYszxZU0N3rGNM1fr3NSlVTF4/cOsdjH9bvzE0hPjyQRzcXu3RV8JV9VUyLDOIqg8bUBPmb+fjCJN4+WkdDu/QG2Hqyng67Y9IOkR9qcqfBQngxd3QMHeqqjBj8zSa2SPdQcRlOp2Z7SQMrZsZ67dD1oZamRbOvoomevot/AD1a20pbT59Xzw+8kJuuSCAy2MI312ZxrwdWSYQYqy+sSKeh3c5fx9CkpKKhgyfzrdw6P9GjpduBFjNfWpXOvoqz50rHx6uqqZMdpQ18clGSoT8/1y9Jodeh+ct+aRqzobCWmFB/lqZFGR2K4SQRFMJLWW0dAC6dIThUSIAfS9Ki2CL7BMVlHK1toanD7vX7AwflpUfT3evkUOXFhygPNoTwtQYryVHBHPiP63hoVYbRoQhxSUvTopiXFMHvtpfhcI58dU1rzfdfP0aA2cR3bprlxggv7I7FySREuG5V8C/7q1AKPmnw6n1GXBhL06J4ce8pnKP485ho2nv62HKynpuuSMDPLGmQ/B8QwkuV1rcTaDGRGOG+DfKrs+Mos3VwqrHDba8hfF9+kQ2lYHmmb6yeLUmLxqQuvU9wl7WRrKlhxIYFeDAy1zD7wKqsEEopvrAynYrGTt45dnrEz9t47DT5xTb+5bqZxIUHujHCCwvwM/OlVRkcOHWW90rG10HU4dT85UA1yzNjmebmZjcjsX7JdKqautheMnnnbr974gzdvU4pCx0giaAQXspqayctJtStpSSrB8ZISHmouJTtJTbmJEYQHeobSVNEkIWcxAgKLrJPsKfPwb6KJp/pFiqEr1qbE8/06GCezLeOaHWt097HDzYcZ1ZCOJ9dNt0DEV7Y7YuSSIwI5LFxrgq+V2KjrqWbO7xkL+/anHhiQv15fvfkbRqz4XAt8eGBLEyZYnQoXkESQSG8VP/oCPfsDxw0PTqEtNgQSQTFRbV09XKwstlnykIH5aVH837lWbrs5+8TPFTZTHev0+caxQjha8wmxeeXp3G4uoXdZZdvTPbLd0upbenmv2/LMbRsb3BV8GBlM9vHsSr4yv4qpgRbuHa2d3Rb9vczcfuiZLacPENtc5fR4XhcS2cv+cU21s1N8In97p4giaAQXqjL7qCmucttHUOHWpMdx56yJjp6+tz+WsL3FJQ24HBqVmb5ViK4LD2aXofmwKmz5z2209qISfWXkAoh3OsTC5OIDvHnt9utlzyvtL6N379XxicXJrFwuvFNPG5flMy0yCAe3TS2VcHG9h42HT/DRxckEeBndkOEY3NXbgoaeGlfldGheNzGY6fpdWgpCx1CEkEhvFB5QwdaQ7obhskPtyo7DrvDyY7S8e2FEBNTfrGNsEA/FiRHGh3KqCxOjcLPpM41hRlql7WBOdMiiAiyGBCZEJNLoMXMPXmpbCuycaKu9YLnaK357t+PERLgx7dvzPZwhBfm72fioVUZHKpqZlvx6PfUvfZ+Db0ObdjswItJjgrmmpmxvLS3kl7H5JojvKGwlpSoYOYmRRgditeQRFAIL2S1DYyO8MCK4OLUKMIC/Ngq5aFiGK01+cU2rs6I8bnuaiEBfsxLjjxvn2CnvY/3K5tlf6AQHvSZZdMJspj53fayCz7++uFadpU18s21WV61F/kTC5OYFhnEY6NcFdRa8/K+KuYnR5IVH+bGCMdm/ZLp1Lf18O6JM0aH4jEN7T0UWBu5eV4CSklZ6CDfemcXYpIorW9HKZgR4/4VQYvZxPKZMWwtqnfpAF3h+0rq26lr6fa5/YGD8tKjOVLTQlt377lj+yrO0ufUhg12FmIyigz2587cZF4/XEvNsL1pbd29/PCfJ5ibFMFduSkGRXhh/n4mvrw6g8PVLWwdxail96uaKalv97rVwEGrsuNIjAicVE1j3jp6GodTs26ulIUOJYmgEF7IamsnaUoQgRbP7CtYlRXHmdYejtVeuGxHTE6bB+4Wr/DRRHBZejQOp2ZfxQdNKgqsDVjMikWp0jFOCE+6/+oZaOCZHeUfOv7ophJs7T38921zvHI0yscXJpE0JYjHNpeM+GbpK/uqCLKYWTc3wc3RjY3ZpLgrN4UdpQ2UN0yO8VEbDteSERdKtheu0BpJEkEhvJDV1kGGB8pCB12T1d/RTMpDxaBNx8/w6KZilsyIItEL5l+NxZUpU/D3M1FQ+kF56C5rIwuSpxDs72dgZEJMPklTgrllXiJ/3ltJS2f/Kv2Julb+uKuCT+WmMDfJO/chW8z9q4KF1S0j6rDd0dPHhsO1fGRuAmGB3rsP+Y7FyfiZFC/uOWV0KG53uqWbfRVN3Dw3UcpCh5FEUAgv43RqymztHtkfOCg2LIB5SRFsGUXpi5i43j5axxefP8DshHCe+swio8MZs0CLmYUpU84Nlm/p7OVoTYvsDxTCIA+sSKPT7uD5PadwOjXf/ftRIoIsfHNtltGhXdLHrkwiJSp4RKuC/yyso8Pu4E4vLQsdFBceyPU5U/nLgWq6e88fszOR/PNIHVrDunneuUJrJEkEhfAyNc1d9PQ5SXfzDMHhVmdP5VBVM43tPR59XeFd3iis5aEX32duUgTPfW4JEcHee0d7JPLSozle18rZDju7yxtxamR+oBAGmZUQzsqZsfxhZzkv7q1k/6mzfPvGbCKD/Y0O7ZIsZhMPr87gSE0Lm09c+obpy/urSIsNYeF07y8/X79kOs2dvbx1tM7oUNxqw+FaZieEe/QGu6+QRFAIL+PJjqFDrc6OQ2vYVjT6NtliYvjHoRq+8uf3uTIlkj/dv4RwLy5rGqll6dFoDXvKG9llbSTQYmJ+ineWoAkxGXxhZRoN7Xa++4+jLJw+hU9cmWR0SCPysQXTmB4dzGObL95BtLS+jQOnznLHomSfKEHMS48mLSZkQjeNqWrq5FBVs8wOvAhJBIXwMlZb/8bt9Fj3dwwdKicxnNiwACkPnaT+eqCaf3n5ELkzonj23lxCAybGHrq5SZEE+5vZZW2kwNrA4tQorxruLMRksywtmrlJESjgkVvnYPLCBjEX4mc28eXVmRyrbeWd4xceu/DK/mr8TIqP+Uhyq5TiU0tSOHDq7EVnPPq6DYW1AF7buMdokggK4WVK69uJDLYQFeLZUhmTSbEqK5btxbZJN2R2sntlXxXfePUwy9Kj+cM9uYRMkCQQ+tu/L06N4u1jpyk+006ejI0QwlBKKX5++zx+f/ciZieGGx3OqNw2P5HU6GB+cYG9gvY+J387WM2aWXHEhvkcR20AACAASURBVHnPLMTL+cTCJPz9TLwwQZvGbDhcx4KUSJKjgo0OxStJIiiEl7Ha2smIDTWkrGR1dhxt3X0cOHXW468tjPHCnlN866+FLM+M5em7FxPkP/FWy/LSoznT2nPueyGEsTLiwlidPdXoMEZtcFXweF0rG499eFVwy8kzNLTbvXZ24MVEBvuzbm4Crx2sob2nz+hwXKq0vp0Tda3cLLMDL0oSQSG8jKc7hg51dWYsFrOSMRKTxJ92VfCd146yOjuOpz6z0GNzKz1tsEtoWKAfOT62AiGE8C63zk9kRkwIj20uxun8YFXw5X1VTA0PYEWm781dXb9kOh12B68fqjU6FJd6o7AWpeAjUhZ6UZIICuFFmjvtNLTbSY/z7P7AQaEBfiyZEc27kghOeE/vKOd7/zjGdbOn8uSnJ24SCJCTGEFEkIWladH4meVtTwgxdn5mE19Zk8HJ021sPHYa6J9Tl19s4xMLk3zyZ8yVKZHMSgjn+d2nLjsew1dordlwuJbc1CimhgcaHY7XmjgbQYSYAD5oFGNci+NV2XE88sZxqpo6paZ+gvptvpX/feskN86J55d3LcDigx9cRsNsUjx3fy7Rob6zb0cI4b1umTeNX20p5bHNJazNiefVA1U4Ndy+yLfKQgcppVi/JIX/+PtRbntiJ2Y3N/AJC7SQHBVE8pRgkqOCB/4bRESQxWXbYk7UtWG1dXDvVTNccr2JShJBIbyIUaMjhlo9kAhuOVnP3XmphsUh3OOJraX8ZGMR6+Ym8Ogd8yd8EjhobpKMjBBCuIbZpPjqmky++tIh3jxaxyv7q1mWFs30aGOqeVzhowumsbuskZauXre+jtbQ2NHDoarm814rLMCPpKhgkqcEDSSIA/+NCiZpShDB/iNPWzYU1mI2KW6cE+/q38KEIomgEF7EWt+Ov9lE0pQgw2KYERPCjJgQSQQnGK01v3i3hMc2l3Db/ER++sl5PlnCJIQQ3mDd3ER++W4J33ntKC1dvXz9uplGhzQuIQF+PP6pKz36mq3dvVQ1dVLV1EX12c7+7892Ud7QwfYSG929H+5gHhPqT9K5VcSgD60mJkYGnbuxqbXmjcJarsqIkUqQy5BEUAgvYrW1kxoTbPgH9FVZcTy/5xSd9r5R3YET3klrzc/eKebxraV8YmESP/74XLeX/gghxERmNim+MrAqGBboxw2y8jRq4YEWchIjyEmMOO8xrTUN7XYqmzo/SBKbuqg628mhqrO8eaQOx5BmPSYFCRFBJEcF/f/27jy+qurq//hnJSGBQJgT5nkWUEBAsWqdcaxIHaBPW7VWq9apDq2dfu1jq0+rnWtrW1uH1lbUAmqd59kKSJhkEAIICUPCTBLIuH5/3BONSJhyc8+9Od/365UXN/uce+4KK/fcs7L32ZuOrTNZu2UX1540KJE/TkrSFZ5IEikoKWNYt5yww+CkoXnc9/Yq3lmxmVMOS70pvuUT7s7PnlvKn19fyZRxvbjjvJEps4CziEgyO/vw7jz034+Y0L9Ts55wKwxmRm5OFrk5WRzZp8NntlfX1LJ++27Wbi2nMCgQ63oU56zeSrd2LZk4XMX5/sS1EDSz+4CzgWJ3HxG0XQD8GBgGjHf3OUF7X2AJsCx4+n/d/cpg25HAA0Ar4Bngem8u0xiJNKCiuoY1W8o5OwmmOR7fryOtM9N5eWmxCsEU5u789Okl/O2tVXz56N7c9oURKgJFROIkPc147Mpjwg4jkjLS0z6+f5ABYUeTuuI9/uwB4PQ92hYBk4E39rJ/gbuPCr6urNd+D3A5MCj42vOYIs3Oms3l1NR6qBPF1MnMSOO4Qbm8tqy42UwlHTXuzv/+ZzF/e2sVlxzTl5+cqyJQREREPhHXQtDd3wC27NG2xN2XNfCUzzCzbkBbd/9v0Av4d2BSPOMUSUbJMGNofScNzWP99t0sWb8z7FDkINXWOj94fBEPvLOarx/bjx+dc1jcpuQWERGR5iHsKeP6mVm+mb1uZscFbT2Awnr7FAZte2VmV5jZHDObU1JS0pSxijSpFcWxQrB/bnJMP33C0FwAXl2mxeVTSW2t872ZC/nne2u48vMD+P5Zw1QEioiIyGeEWQiuB3q7+2jgRuBfZtb2YA/i7n9x97HuPjY3NzfuQYokSkFJGd3ataR1VnLM4ZSX05KRPdrxylIVgqmipta55d8LmDZ7LdeeNJDvnD5ERaCIiIjsVWiFoLtXuPvm4PH7QAEwGCgCetbbtWfQJtKsFZSUMjAvOYaF1jlxaB75a7aytawy7FBkP6prarnp0XlMn1vIt04ZzE2nqQgUERGRhoVWCJpZrpmlB4/7E5sUZqW7rwd2mNnRFruK+SrwRFhxiiSCu1NQXJo09wfWOWloHrUOr3+oYdfJrKqmlhsemcfj89Zxy8QhXH+K1k4SERGRfYtrIWhmDwPvAkPMrNDMLjOz88ysEJgAPG1mzwe7Hw8sMLN5wL+BK929bqKZq4G/AiuI9RQ+G884RZLNxh0VlFXWMCBJ7g+sc3iPdnRuk8nLGh6atCqra7nu4XyeWrCe754xlG+eODDskERERCQFxPVmJHef2sCmmXvZdzowvYHjzAFGxDE0kaSWbDOG1klLM04YkscLH2ygsrqWzIyw55eS+iqqa7jmX/m8uHgjPzhrGF8/rn/YIYmIiEiK0FWdSBKomzF0QJLdIwhwzhHd2bG7mkfnrA07FKlnd1UNVz00lxcXb+S2c4erCBQREZGDokJQJAkUlJTSJiuDvJyssEP5jOMHdWZc3w789uXl7KqsCTscIfb7cun9s3llaTF3nDeSr07oG3ZIIiIikmJUCIokgYKSUgbktUnKWR7NjG+fPpSSnRXc/86qsMOJtOKdu/n+zIWc9us3mF+4jV9ccARfOqp32GGJiIhICkqOBctEIq6guIxjBnYKO4wGjevbkZOH5vGn1wr4n/F9aJfdIuyQIqW0opq/vLGSv765ksrqWv7nqN5ce9IgcpOwB1lERERSg3oERUJWWlHNhh27k26imD3dPHEIOyuquef1grBDiYzK6loefGc1n7/zVX738nJOHJLHizd+ntvOHaEiUERERBpFPYIiIVuZpDOG7mlYt7ZMGtWD+99exSXH9KVru5Zhh9RsuTtPLVjPL15Yxkebyzm6f0f+dsYwRvVqH3ZoIiIi0kyoR1AkZHUzhg7MS641BPfmW6cMptad372yPOxQmq13CjZx7h/e5tqH82mZkc79l4zj4cuPVhEoIiIicaUeQZGQFZSUkp5m9O6Y/IVg707ZfGl8bx56bw2XH9effp2TP+ZUsWT9Dn7+3FJeW1ZC93Yt+cUFR3De6B6kpyXfBEIiIiKS+lQIioSsoLiMPp2yU2ax9mtOGsRj7xfyqxc/5PdTR4cdTsor2raLX76wjJn5ReRkZfDdM4Zy8TF9adkiPezQREREpBlTISgSsoKS0qS/P7C+3JwsLju2H79/ZQXfOL4/I3q0CzuklLStvJI/vlbAA++sBuCK4/pz9QkDNSOriIiIJERqdEGINFPVNbWs3lyWUoUgwOXH96d9dgvuen5Z2KGknN1VNfzp9QKOv/NV7n1zJV84ojuv3nwC3z1zmIpAERERSRj1CIqEaO3WXVTVOANyU+teu7YtW3D1CQO445mlvFuwmQkDkncNxGRRU+vMmBsbUrt++25OHJLLd84YytCubcMOTURERCJIPYIiISoIZgwdkJdaPYIAX53Ql65tW3Ln80tx97DDSVruzitLN3Lmb9/kln8vIC8ni4cvP5r7Lx2vIlBERERCox5BkRCtqFtDsHPqFYItW6RzwymDuHXGQl5cvJHThncNO6SkM2/tNv7vmSW8t2oLfTtl84cvjeHMkV0x00ygIiIiEi4VgiIhKigupXObrJS9N+z8I3vylzdWctfzyzh5WBctdRBYtamMu55fyjMLN9C5TSY/OXc4U8b3pkW6BmGIiIhIctBViUiICkpKU2Ih+YZkpKdx88QhLC8uZWZ+UdjhJIUn56/j1F+9zmvLSrj+5EG8dsuJfGVCXxWBIiIiklR0ZSISEnenoCT1Zgzd0xkjujKyRzt+/eKHVFTXhB1OqN4t2MxNj85jTO8OvHbLCXzr1MG0ydLACxEREUk+KgRFQrK5rJLtu6pSvhA0M75z+lCKtu3iX++tCTuc0Hy4cSdX/GMOfTq15t6vjiUvp2XYIYmIiIg0SIWgSEhSecbQPR07qDOfG9iJu19ZQWlFddjhJNzGHbu55L5ZtGyRzgOXjkvZez5FREQkOlQIioTk4xlDU2wNwYZ8e+JQNpdV8rc3V4UdSkLt3F3FJffPZvuuKu6/ZBw9O2SHHZKIiIjIfqkQFAlJQXEZrVqk071dq7BDiYsjerXn9OFduffNlWwurQg7nISoqqnl6n/O5cONO/njl49kRI92YYckIiIickBUCIqEpKCklP65rUlrRksu3DxxMOWV1fzxtYKwQ2ly7s6t0xfy5vJN/N/kkXx+cG7YIYmIiIgcMBWCIiEpKClN+Yli9jQwL4fzj+zJP979iKJtu8IOp0n9+qXlTJ9byA2nDOLCsb3CDkdERETkoMS9EDSz+8ys2MwW1Wu7wMw+MLNaMxu7x/7fNbMVZrbMzCbWaz89aFthZrfGO06RMO2qrKFo265mVwgCXH/KYDD4zYsfhh1Kk5k2aw2/e3k5F47tyfUnDwo7HBEREZGD1hQ9gg8Ap+/RtgiYDLxRv9HMDgOmAMOD5/zRzNLNLB34A3AGcBgwNdhXpFlYtakMdxiQwovJN6RH+1Z89eg+TJ9byPKNO8MOJ+5eXVbM9x9fxPGDc7n9vJGYNZ+hvSIiIhIdcS8E3f0NYMsebUvcfdledj8XmObuFe6+ClgBjA++Vrj7SnevBKYF+4o0C5/MGNr8egQBrj5xINmZGfzihb297VPXwsLtfPOfcxnaNYc//s8YWqRrdL2IiIikprCvYnoAa+t9Xxi0NdQu0iwUFJdiBv06N78eQYCOrTO54vj+PP/BRuat3RZ2OHGxdks5lz4wmw7Zmdx/yTjaZGWEHZKIiIjIIQu7EGw0M7vCzOaY2ZySkpKwwxE5IAUlpfTqkE3LFulhh9JkLju2H51aZ/LzZ5fi7mGH0yjbyiu5+P5ZVFbX8ODXxpHXtmXYIYmIiIg0StiFYBFQf7q9nkFbQ+2f4e5/cfex7j42N1fTt0tqKCgpazYLyTekdVYG1540kHdXbuatFZvCDueQ7a6q4fK/z6Fwyy7u/epYBublhB2SiIiISKOFXQg+CUwxsywz6wcMAmYBs4FBZtbPzDKJTSjzZIhxisRNba2zshkuHbE3U4/qTY/2rbjzuWXU1qZer2BtrXPTo/OZvXorv7zwCI7q3ynskERERETioimWj3gYeBcYYmaFZnaZmZ1nZoXABOBpM3sewN0/AB4FFgPPAd909xp3rwauAZ4HlgCPBvuKpLyibbuoqK5lQF7zLwSzMtK58dTBLCzazrOLNoQdzkG745klPL1wPd87cyjnHNE97HBERERE4ibusx24+9QGNs1sYP/bgdv30v4M8EwcQxNJCs19xtA9TRrdgz+/UcAvXljGacO7pMxMm/e9tYq/vrWKS47py+XH9Q87HBEREZG4So0rMpFmpKC4rhBs3vcI1klPM26ZOJRVm8r49/uFYYdzQJ5duJ6fPL2YicO78MOzD9NagSIiItLsqBAUSbCCkjLaZ7egY+vMsENJmFOG5TGmd3t+89KH7K6qCTucfZqzegs3PDKP0b3a89spo0lPUxEoIiIizY8KQZEEKygpZWBum0j1MpkZ3zl9KBt3VPDgO6vDDqdBBSWlfP3vc+jevhV/vXhcs17eQ0RERKJNhaBIgkVlxtA9HdW/EycMyeWPrxWwfVdV2OF8RsnOCi65fxbpZjxw6bhI9diKiIhI9KgQFEmgbeWVbCqtZEBeNO4P3NMtE4ewfVcV976xMuxQPqW8sprLHpxNyc4K/nbJOPp0imZ+REREJDpUCIokUEHEZgzd0/Du7fjCEd3521urKN65O+xwAKiuqeWaf+WzqGg7d08dw6he7cMOSURERKTJqRAUSaCC4jIguoUgwI2nDqaqppa7X1kRdii4Oz984gNeWVrMbeeO4JTDuoQdkoiIiEhCqBAUSaCCklIy09Po2aFV2KGEpm/n1lw0rhf/em8NazaXhxrLH18r4OFZa7jqhAF8+eg+ocYiIiIikkgqBEUSqKCklH6dW5ORIouqN5XrTh5ERrrxqxeXhRbDjLmF3PX8MiaN6s4tpw0JLQ4RERGRMET7alQkwQpKyiI7UUx9Xdq25NLP9eOJ+etYvG5Hwl//reWb+Pa/FzChfyfuPP8I0rRWoIiIiESMCkGRBKmormHNlvJI3x9Y35XHDyAnK4NfvJDYXsEl63dw5UPvMyC3DX/6ypFkZug0KCIiItGjKyCRBFmzuZyaWlchGGiX3YKrThjIK0uLmbVqS5O/Xk2ts3zjTi69fzZtsjK4/9JxtGvVoslfV0RERCQZZYQdgEhUrCiO9tIRe3PJMX25/+1V3PncUh67cgJmhz5E093ZUlbJ2q27WLulnLVby1m7ZReFW8tZu6Wcom27qKpx2mRl8NiVE+jeProT9oiIiIioEBRJkLo1BPvn6h7BOq0y07n+lEF8f+YiXl1WzElD9718Q1lF9ccF3ifF3icFX1llzaf275Ddgl4dsxnevR0TR3SlV4dsPjewM/06KwciIiISbSoERRKkoKSM7u1a0jpLb7v6Lhzbi3vfWMmdzy3jmAGdWb9996d69NZuLadwSzlrt+5iS1nlp56bnZlOrw7Z9OrYigkDOtGrYza9OrSK/dsxmzb6vxYRERHZK10liSRIQUkpA/I0LHRPLdLTuPG0IVz3cD5Df/jcHtuMHu1jhd3E7u3o1bFVUPjFCr6OrTMbNZxUREREJKpUCIokgLtTUFzKBWN7hR1KUjp7ZDdWbyqjptY/1avXpW1L0rW0g4iIiEjcqRAUSYCNOyooq6xhgO4P3Ku0NOO6kweFHYaIiIhIZGj5CJEE0IyhIiIiIpJMVAiKJEDdjKG6R1BEREREkoEKQZEEKCgppU1WBnk5WWGHIiIiIiKiQlAkEepmDNUMlyIiIiKSDFQIiiRAQXGZJooRERERkaShQlCkiZVWVLNhx25NFCMiIiIiSSPuhaCZ3WdmxWa2qF5bRzN70cyWB/92CNpPMLPtZjYv+Pp/9Z5zupktM7MVZnZrvOMUSZQCzRgqIiIiIkmmKXoEHwBO36PtVuBldx8EvBx8X+dNdx8VfN0GYGbpwB+AM4DDgKlmdlgTxCrS5OpmDB2Yp6GhIiIiIpIc4l4IuvsbwJY9ms8FHgwePwhM2s9hxgMr3H2lu1cC04JjiKScgpJS0tOM3h1VCIqIiIhIckjUPYJd3H198HgD0KXetglmNt/MnjWz4UFbD2BtvX0KgzaRlFNQXEafTtlkZuiWXBERERFJDhmJfkF3dzPz4Nu5QB93LzWzM4HHgUEHczwzuwK4AqB3795xjVUkHgpKSnV/oIiIiIgklUR1UWw0s24Awb/FAO6+w91Lg8fPAC3MrDNQBPSq9/yeQdtnuPtf3H2su4/Nzc1typ8haa0o3skrSzeGHYbsRXVNLas3l6kQFBEREZGkkqhC8Eng4uDxxcATAGbW1YIVts1sfBDPZmA2MMjM+plZJjAlOIbsxQ8eX8SV/5jLlrLKsEORPazZUk5VjWsNQRERERFJKk2xfMTDwLvAEDMrNLPLgJ8Bp5rZcuCU4HuA84FFZjYf+B0wxWOqgWuA54ElwKPu/kG8Y20OCreW89+VW6isqWXG3MKww5E9FJSUATAgTz2CIiIiIpI84n6PoLtPbWDTyXvZ927g7gaO8wzwTBxDa5aemLcOgH6dW/OvWWu47Nh+BJ2skgTqlo7Q0FARERERSSaaxjCFuTvT5xYyvm9Hrj5hACtLypi9emvYYUk9BcWl5OZk0a5Vi7BDERERERH5mArBFDa/cDsrS8qYPKYHZx3ejZysDKbNWhN2WFJPbMZQ3R8oIiIiIslFhWAKmzm3kMyMNM4Y2Y3szAzOHd2dpxeuZ3t5VdihCbEe24ISzRgqIiIiIslHhWCKqqyu5cn56zj1sC4fDzucMq43FdW1zMzXpDHJYHNZJdt3VakQFBEREZGko0IwRb3+YQlby6uYPLrHx20jerRjZI92TJu9FncPMToBWFEcTBSjGUNFREREJMmoEExRM+YW0ql1JscPzv1U+9TxvVm6YSfz1m4LKTKp88mMobpHUERERESSiwrBFLS9vIqXlxTzhVHdaZH+6RR+YVR3sjPTmTZrbUjRSZ2C4jJatUine7tWYYciIiIiIvIpKgRT0FML11FZU8vk0T0/s61NVgbnHN6d/yxYx87dmjQmTAUlpfTPbU1amtZ1FBEREZHkokIwBc2YW8SgvDaM6NF2r9unjO9FeWUNT85fl+DIpL7Y0hG6P1BEREREko8KwRTz0eYy3v9oK+eN6YHZ3nuaRvVqz9CuORoeGqJdlTUUbdulQlBEREREkpIKwRQzY24RZjBpVI8G9zEzpo7vzcKi7Swq2p7A6KTOw7PW4A4je+6911ZEREREJEwqBFOIuzMzv4hjBnSie/t9T0AyaVQPsjLSmDZ7TYKikzrLNuzkZ88t5eSheZw4JC/scEREREREPkOFYAp5/6OtrNlSznl7mSRmT+2yW3DWyG48nr+O8srqBEQnABXVNVw/LZ+2LTP4+fmHNzh8V0REREQkTCoEU8j0uUW0apHO6SO6HtD+U8b3prSimqcWrG/iyKTOL55fxtINO/n5Fw+nc5ussMMREREREdkrFYIpYndVDU8vWMfE4V1ok5VxQM8Z17cDA3JbM22WhocmwtsrNnHvm6v4n6N6c/KwLmGHIyIiIiLSIBWCKeKVpcXs2F3N5DH7HxZap27SmLlrtvHhxp1NGJ1sL6/ipkfn0z+3NT8467CwwxERERER2ScVgilixtwi8nKy+NzAzgf1vMljepKZnsbD6hVsMu7O9x5fyKbSCn570WhaZaaHHZKIiIiIyD6pEEwBm0sreG1ZMZNG9yA97eAmH+nYOpPThndhxtwidlfVNFGE0TYzv4inF6znW6cOZmTPdmGHIyIiIiKyXyoEU8B/5q+jutaZPKbhtQP3Zer43mzfVcVzizbEOTJZu6Wc//fEB4zr24ErPz8g7HBERERERA6ICsEUMDO/iGHd2jK066EtTj6hfyf6dMrW8NA4q6l1bnx0Hgb86sJRB91bKyIiIiISFhWCSW5FcSnzC7fzxUPsDQRISzMuGteL91ZtYWVJaRyji7Y/vV7A7NVbuW3ScHp1zA47HBERERGRA6ZCMMnNzC8kzeALR3Rv1HHOP7InGWnGtNlr4xRZtC0o3MavX/yQsw/vxqRRh16ki4iIiIiEQYVgEqutdR7PX8dxg3LJa9uyUcfKy2nJycPymP5+IZXVtXGKMJrKK6u5Ydo8cnOyuH3SSMw0JFREREREUosKwST23qotFG3bdciTxOxp6vjebC6r5MXFG+NyvKi6/eklrNpcxi8vPIJ22S3CDkdERERE5KDFvRA0s/vMrNjMFtVr62hmL5rZ8uDfDkG7mdnvzGyFmS0wszH1nnNxsP9yM7s43nGmghlzC2mTlcFph3WNy/GOG5RLj/atmDZbk8YcqpcWb+Sf763h8uP6c8yAg1vTUUREREQkWTRFj+ADwOl7tN0KvOzug4CXg+8BzgAGBV9XAPdArHAEfgQcBYwHflRXPEbFrsoanlm4njNGdI3bAuXpacaFY3vx5vJNrN1SHpdjRknJzgq+M30Bw7q15abTBocdjoiIiIjIIYt7IejubwBb9mg+F3gwePwgMKle+9895r9AezPrBkwEXnT3Le6+FXiRzxaXzdoLizdQVlnDeXEaFlrnwnE9STPUK3iQ3J3vTF/AzopqfjtlFFkZ8SnORURERETCkKh7BLu4+/rg8QagS/C4B1B/GsvCoK2h9s8wsyvMbI6ZzSkpKYlv1CGaMbeI7u1acnS/TnE9brd2rThhSB6PzSmkukaTxhyoh95bwytLi/nuGUMZ3CUn7HBERERERBol4ZPFuLsDHsfj/cXdx7r72Nzc3HgdNlTFO3fz5vISzhvTg7QmWKR86vjeFO+s4JWlxXE/dnO0oriU259ezPGDc7l4Qt+wwxERERERabREFYIbgyGfBP/WVSBFQK96+/UM2hpqj4Qn562j1uG80T2b5PgnDsmlS9ssrSl4ACqra7nhkXxatUjnrvMPb5LCXEREREQk0RJVCD4J1M38eTHwRL32rwazhx4NbA+GkD4PnGZmHYJJYk4L2iJh+twijujZjoF5bZrk+BnpaVxwZC9eW1bMum27muQ1movfvPQhi4p28H+TD6dLI9dyFBERERFJFk2xfMTDwLvAEDMrNLPLgJ8Bp5rZcuCU4HuAZ4CVwArgXuBqAHffAvwEmB183Ra0NXtL1u9gyfodnDc6vpPE7Omicb2odXh0jnoFGzJr1Rbueb2Ai8b24vQR8VnCQ0REREQkGWTE+4DuPrWBTSfvZV8HvtnAce4D7otjaClhZn4RGWnGOUd0b9LX6dUxm+MGdebR2Wu59qRBpGvI46fs2F3Ftx6ZR++O2fy/cw4LOxwRERERkbhK+GQx0rCaWufx/CJOGJJLpzZZTf56U8f3Zt323byxvPnMthovP3riAzbs2M2vLxpF66y4/71ERERERCRUKgSTyNsrNlG8s4LJY5pmkpg9nTKsC51aZzJtltYUrO/J+euYmV/EtScNZEzvDmGHIyIiIiISdyoEk8jM/CLatszgpKF5CXm9zIw0zj+yJy8tKaZ4x+6EvGayW7dtFz+YuZBRvdpzzYkDww5HRERERKRJqBBMEqUV1Ty3aANnHd6dkKN5/gAAGEBJREFUli3SE/a6F43rRU2t89j7hQl7zWRVW+vc9Oh8qmud31w0iox0vT1EREREpHnSlW6SeG7RBnZV1fDFMU07W+ie+ue24ej+HXlk9lpqaz2hr51s/vrWSt5duZkfnzOcvp1bhx2OiIiIiEiTUSGYJGbmF9K7YzZH9kn8PWlTx/dmzZZy3l25OeGvnSwWr9vBXc8vY+LwLlwwNjH3aIqIiIiIhEWFYBJYv30X7xRs5rzRPTBL/DIOE4d3pX12C/4V0UljdlfVcP20fDpkZ/J/kw8PJQciIiIiIomkQjAJPJ6/DneYnOBhoXVatkjnvNE9eOGDDWwurQglhjD97NmlLC8u5a4LjqBj68ywwxERERERaXJaIC1k7s6MuYUc2acDfTqFd1/a1PG9uf/t1cyYW8Tlx/cPJYalG3Zww7R5bC2vZGjXtgzr1pZh3XIY2rUt/XNb06IJJm95/cMSHnhnNZcc05fPD86N+/FFRERERJKRCsGQLSrawfLiUm4/b0SocQzuksORfTrw8Ow1fP24fgkfHjkzv5DvzlhITssWHDuwM0s37OSdgpVU1cQmsMlMT2NgXhuGdsthWNe2sX+7taVzm6xDfs0tZZXc/Nh8Bndpw61nDI3XjyIiIiIikvRUCIZsRn4hmelpnD2ye9ihMGVcL2759wJmr97K+H4dE/KaFdU1/OSpxTz03zWM79eRu780mryclgBU1dSysqSMJet3sGTDDpau38nbKzYxY27Rx8/v3CYr6DWMFYZDu7ZlQF5rsjL2vQSHu3Pr9AVsL6/iwUvHJ3TJDhERERGRsKkQDFFVTS1PzlvHycPyaJfdIuxwOOvwbtz2n8U8PGtNQgrBom27uPqfc5m/dhtXHN+fWyYO+dTwzxbpaQzpmsOQrjlM4pP7JzeXVrBsw06WbNjJ0qBIfPDdj6isrgUgI80YkNvm417DuiIxLyfr457OR+es5YXFG/nemUM5rHvbJv9ZRURERESSiQrBEL25vITNZZVMHpMcyxVkZ2Zw7ujuPDankB+fM7xJi9M3Pizh+mn5VNU4f/ryGE4f0e2An9upTRbHDMzimIGdP26rrqll9eYylqzfyZL1O1i6YSezV23hiXnrPt6nQ3YLhnVry+AuOTw6Zy0T+nfi68eGcz+kiIiIiEiYVAiGaPrcIjpkt0iqSUqmjOvNQ/9dw8z8Qi75XL+4H7+21vnDqyv41UsfMjgvh3u+PIb+uW0afdyM9DQG5uUwMC+Hc474ZJjt9vKqYFhprDhcsmEn02avoVWLdH554RGkpWmpCBERERGJHhWCIdm+q4oXF29k6rheZGYkzyoeI3q04/Ce7Zg2ey0XH9M3rpPGbCuv5FuPzOPVZSVMGtWdOyaPJDuzaX8F22W34Oj+nTi6f6eP22pqnaqaWt0XKCIiIiKRlTwVSMQ8u3A9ldW1nJckw0LrmzKuN0s37GTe2m1xO+aiou2c/fu3eGvFJn4yaQS/vmhUkxeBDUlPMxWBIiIiIhJpKgRDMmNuEf1zW3NEz3Zhh/IZXxjVnezMdB6etSYux3tk9hom3/MONbXOo9+YwFeO7pPw5SlEREREROQTKgRDsHZLObNWb+GLY3omZUHUJiuDcw7vzn/mr2fn7qpDPs7uqhpueWw+35m+kKP6deSpa49ldO8OcYxUREREREQOhQrBEMzMj62Dd+6o8NcObMjUo3qzq6qGJ+ev2//Oe7FmczmT//gOj71fyHUnDeSBS8fTqRGLv4uIiIiISPyoEEwwd2dmfhFH9+9Izw7ZYYfToCN6tmNo1xymzVp70M99afFGzv79mxRuLee+S8Zy42lDSNfsnCIiIiIiSUOFYILlr93Gqk1lTB6dfJPE1GdmTB3fm4VF21lUtP2AnlNT69z1/FK+/vc59OqYzdPXHcdJQ7s0caQiIiIiInKwVAgm2Iy5hWRlpHHGyK5hh7Jfk0b1ICsj7YAmjdlcWsFX73uPP7xawJRxvZh+1TH06pi8PZ4iIiIiIlGmQjCBKqpreGrBek4b3pWcli3CDme/2mW34KyR3Xhi3jrKK6sb3G/umq2c/fu3mL16K3d+8XB+9sXDtTyDiIiIiEgSUyGYQK8uLWFbeRWTx/QIO5QDNvWo3pRWVPPUgvWf2ebuPPjOai7687tkpBszrjqGC8f1CiFKERERERE5GAkrBM3sejNbZGYfmNkNQduPzazIzOYFX2fW2/+7ZrbCzJaZ2cRExdmUZuYX0rlNFscN7Bx2KAdsbJ8ODMxrw7Q9hoeWV1ZzwyPz+NGTH3D8oFyeuuY4RvRIvjURRURERETkszIS8SJmNgK4HBgPVALPmdlTweZfu/sv9tj/MGAKMBzoDrxkZoPdvSYR8TaFrWWVvLK0mK9O6EtGeup0xJoZU8b14qdPL2HZhp0M6ZpDQUkpVz30PiuKS7ll4hCu+vwA0jQrqIiIiIhIykhURTIMeM/dy929GngdmLyP/c8Fprl7hbuvAlYQKyJT1lML1lFV4yk1LLTO5DE9yUyPTRrzzML1fOH3b7GptJK/f+0ovnniQBWBIiIiIiIpJlGF4CLgODPrZGbZwJlA3c1k15jZAjO7z8w6BG09gPoL2BUGbZ9hZleY2Rwzm1NSUtJU8TfajPwihnTJ4bBubcMO5aB1bJ3JacO78K/31nD1P+cyuGsOT117LMcOSp0hriIiIiIi8omEFILuvgT4OfAC8BwwD6gB7gEGAKOA9cAvD+HYf3H3se4+Njc3N35Bx9HKklLy12xj8pgemKVm79nFx/Slxp2LJ/ThkSsm0L19q7BDEhERERGRQ5SQewQB3P1vwN8AzOwOoNDdN9ZtN7N7gbr7Bov4pMcQoGfQlpIezy8izWDS6NQbFlpnXN+OLPzxaWRnJuxXRkREREREmkgiZw3NC/7tTez+wH+ZWbd6u5xHbAgpwJPAFDPLMrN+wCBgVqJijafaWmdGfhGfG9iZLm1bhh1Oo6gIFBERERFpHhJ5ZT/dzDoBVcA33X2bmf3ezEYBDqwGvgHg7h+Y2aPAYqA62D8lZwyd89FWCrfu4qbTBocdioiIiIiICJDYoaHH7aXtK/vY/3bg9iYNKgFmzC0kOzOdicO7hh2KiIiIiIgIkMChoVG0u6qGpxes5/QRXTWsUkREREREkoaqkyaUnmbcef7h9OqYHXYoIiIiIiIiH1Mh2IRapKdxxshu+99RREREREQkgTQ0VEREREREJGJUCIqIiIiIiESMCkEREREREZGIUSEoIiIiIiISMSoERUREREREIkaFoIiIiIiISMSoEBQREREREYkYFYIiIiIiIiIRo0JQREREREQkYlQIioiIiIiIRIwKQRERERERkYgxdw87hrgxs53AsrDjkFB0BjaFHYQknPIeXcp9dCn30aXcR5dyf3D6uHvu/nbKSEQkCbTM3ceGHYQknpnNUe6jR3mPLuU+upT76FLuo0u5bxoaGioiIiIiIhIxKgRFREREREQiprkVgn8JOwAJjXIfTcp7dCn30aXcR5dyH13KfRNoVpPFiIiIiIiIyP41tx5BERERERER2Q8VgiIiIiIiIhGTUoWgmeWEHYOEw8xahR2DhEPv++hS7qNL5/xoUt6jS+f7cKREIWhmrc3sD8B0M/uSmfULOyZJDDNrY2Z3A381s9PNrF3YMUli6H0fXcp9dOmcH03Ke3TpfB+ulCgEgduAtsBPgdHAz8INRxLoN0AmMAOYCtwabjiSQHrfR5dyH10650eT8h5dOt+HKGkLQTPrEvzbBmgD3OHubwC3A2lm9oMw45OmY2YW/NsZ6A7c6O7TgV8B3czs8jDjk6ZlZunB8CC97yMoOOfnoNxHhpmlBf92Quf8yAje6/qsjyBd4yePpCsEzay/mU0D7jCzNHcvBboAUwDcfRvwc+B8M+saYqgSZ2Y21Mz+BFxnZm3dfRNQC9R9GCwFZgJnm1nHsOKU+DOzAWZ2KYC717j7LqAret83e2Y2yMx+a2ZXmlkHnfOjw8wGmtmfgZvMrIe7byZ2XfL1YBed85sZi8kys38Tu87LDD7r01Hemz1d4yefpCoEzewO4AXgdXe/zN1rg03/C0wJ/moEsAB4DTgr8VFKUwjGhD8EFABHAPeY2SjgLmBicIFYQSz3q4AxoQUrcWVmVwPvA98ysy/W2/Qj9L5v1szsVmIXfEXACcDfgk065zdzZvZjYDrwITAY+Huw6bfA6WbWXuf85sdjKoDOwVfdOf83KO/Nmq7xk1NSFYLExodvdfd7AMysq5m1cPd84BViwwVw90qgBigJLVKJt6HAJne/C/gGsAyYBOwG5gPfBXD3VUBfoCycMKUJFBD7S/APgS+ZWUsAd58HvAz8Mvhe7/tmxMxaA6XARe5+J3AJMNTMRrn7XOBVlPvmbDFwhrv/ErgJ2GJm2cCbxM4JOuc3U2Y2gFg+XwKOD3p+XiJW+CnvzZeu8ZNQRtgBBPeDpQXDwW42s4/M7H+J/RVoV7DPN4EbgUVmdiWxk8XxxC4UJEUF94W4uzuwCNhtZkPdfamZPQtcQOwvxX8BnjWz/wLrgFzAwopbGq/uniB3r3X354PzQG/gbOAq4NfBrjcTe99/A1iN3vcpLxgOVAuUA9Pdfb2ZZbn7bjPLJzZEDD455yv3zUS93OPujwZtY4CngQ+I3R90O7H3/9Nm9h4656e8+nkPrCOW76XE/gg8EXgW+AXwjPLefASf9aZr/OQVSo+gmXUxsxPh42ECNfU2/wD4FvAA8GViFwvXB/cMfRVoRawb+Tfu/lRCA5dGC3J/FXxcBHiwqQWxIULHBttmA+uB/u5eAHwbGA/cC9zj7u8kPHhplL3k/uMLg+D3oIjYjHGnmNmgoL0c+ArQGr3vU9aeuQ/+dXdfHzyuMLN0YjPGbQnalPtmYG+530MmcLO7nwK0BK5z9xXEegl1zk9R+8n7EKBPkNNVwE+Avwaf9beivKe0vXzW6xo/idkn1+EJekGzHwKXEZse9h/uXha0TwUedfcaM8tz9+KgfTSxeweOCi4MJEWZ2feJDftcD0x195VB+wXu/lgwWchwYr0E75rZ0cQ+HEaEF7XEwz5yP4XY+742+L4rcD1Q5u4/NbPBwHJP9IlK4uYgcn8c8B13PzvoIe7i7hvCilsa70BzX2//us/7o+uuDST17C/vxCYHuZbYkgFnA2uI3Tf2w3AilnjZR+51jZ+kEtojGAwBORo43N3/VK8I7Aa0J/bXQOp+QQLDgFmJjFPiy8yONrOFQDfgYmL3BW0NtvUgNvwDYsMANgI/tNiUwn2B94L7RiQFHUDu2wEtgwt/ggv/B4CLzayM2EWChgaloIPIfd1Q0HbE3u9fJDZsbGLd74WklgPN/V6eOhiYnag4Jb4OIO/tg11ziQ39ywEmAN8BegUTxEkKOoDct0XX+EkpIT2CZpYe/BXgVOB0d7/JzI4i9lehfHdfu8f+LYHDiN04WgPcGgwVlBRksfVi+rn7f4PvXwcec/e797x3IBhPficwMPj6mrvrJJGiDjL36cRmkXsScOAWd38zjLil8Q4m98H2vwJfIzaT5O+U+9R1kO/7dsQ+7+8gtlyQPu9T1EHmvae7FwaPOwEt3b0olMCl0Q4y97rGTyJN1iNoZh3N7OsWmxGobnxwTyDXzM4E/gScDDxZd79g8LyW7r6b2F8M73P3k/ULklrq5z5oKnH3/1psofAWxG4Kb7mXk0Pr4PtvA5e7+wgVgamlEblvFZwndgC/cPejVQiklsa874OH7xH7w88Fyn1qaUTus9x9O9ARuF+f96mlEXnPdvdCM0sLOgo2qwhMLY3Iva7xk0yTFIJmdi6xiT9uAq6ut+mfxNaKugSY6O7XE5sR8jfB87oBv7fYwrKvuvvfkZTSQO4dPl4ovArIAga5e23dsDAz6w782sx6BzcXa9rgFNPI3P/WzPq6+y53fyyE8KURGpn735hZN3e/190fSHz00hiNzP3dwef90/q8Ty1xeM/32stEIpICGpl7XeMnmSYZGmpmRxJbFPxDYmO/r3H3j4Jt3wB+DIxw981m1gG4G7iCWBdxS3ffFvegJCEayr3VWyrCzA4D/gOMdfe6MeQtgbq/DksKUu6jq5G51zk/hSn30aTzfXTpPd+8NEmPoLu/DzxIbI2YxcA36237M/A+8HUzOwf4B7Eu5TJ3361fkNTWUO7900tF7ADeAfrUe95ufTCkNuU+uhqZe53zU5hyH00630eX3vPNS6MKQTNrZWZHBH8F+JSge3gTMBMYamafr7f5KmAJsYkBnnX3GxoThyReI3IPsBvIA/RhkIKU++hS7qNLuY8m5T26lPtoOORC0MyuJNazN55gbHADlgKvAxcEzxsKbHT3J4Hz3f0PhxqDhKMRuR8S3Ci8CTjb3Vc1ebASV8p9dCn30aXcR5PyHl3KfXQc9D2CZtYW+CVwLHCeuy89gOd0IjaD0GHAvcSmiq04+HAlTMp9dCn30aXcR5dyH03Ke3Qp99GTcQjPKQPWAg+4+1IzywWGA++7+876OwbdyZnEFojOAb7i7jMbF7KESLmPLuU+upT76FLuo0l5jy7lPmL22yNoZhnADcAjHiz8bmajgYuB0cTWAllG7JfhH+4+w4IF5Osd40vu/q8m+hmkiSj30aXcR5dyH13KfTQp79Gl3Ms+C0EzG0lsZqAewCvuPrXetsuAIcAPgWrgi8C3gGPqZg0yM/N9vYAkLeU+upT76FLuo0u5jyblPbqUe4H9TxazCfgdMBToa2an1dv2MPB9d68I/jKwOPjKMTOD2GIiTRCzJIZyH13KfXQp99Gl3EeT8h5dyr0c0NDQVu6+y2ILwU919xP2sk8O8Gdgs7tf2ySRSsIp99Gl3EeXch9dyn00Ke/RpdzLfpePcPddwcO/A7vN7Lq6bWaWZmbXA28BH+oXpHlR7qNLuY8u5T66lPtoUt6jS7mXg1o+wswmAre5+1HB2OKlwCigyN3XNVGMkgSU++hS7qNLuY8u5T6alPfoUu6j6aAWlHf354GtZlYB/Bxo7+6z9QvS/Cn30aXcR5dyH13KfTQp79Gl3EfTAReCQRfxT4FhwDXufqa7lzRdaJIslPvoUu6jS7mPLuU+mpT36FLuo+tgh4aeQWyK2YqmC0mSkXIfXcp9dCn30aXcR5PyHl3KfTQdVCEoIiIiIiIiqe+g7hEUERERERGR1KdCUEREREREJGJUCIqIiIiIiESMCkEREREREZGIUSEoIiIiIiISMSoERUSk2TGzG8ws+xCed4mZdT+YY5vZM2bW/lDijLdD/blFRCR6tHyEiIg0O2a2Ghjr7psO4jnpwMvAze4+J57HTpRkjk1ERJKLegRFRCSlmVlrM3vazOab2SIz+xHQHXjVzF4N9rnHzOaY2Qdm9r/1nrvazH5uZnOBqcBY4J9mNs/MWu3lta7by7FXm1lnM+trZkvN7AEz+9DM/mlmp5jZ22a23MzG14v3PjObZWb5ZnbuPn62S8zsCTN7LTjGjxr4mS/aW2wiIiINyQg7ABERkUY6HVjn7mcBmFk74FLgxHo9Y9939y11vX5mdri7Lwi2bXb3McFzv84+egTd/XdmduMex65vIHAB8DVgNvAl4FjgC8D3gEnA94FX3P1rwZDSWWb2kruXNfDzjQdGAOXAbDN7Guiz58/s7tv3E5uIiMjH1CMoIiKpbiFwatCzd5y7b9/LPhcGvX75wHDgsHrbHoljLKvcfaG71wIfAC977B6MhUDfYJ/TgFvNbB7wGtAS6L2PY77o7pvdfRcwg1hheSA/s4iISIPUIygiIinN3T80szHAmcBPzezl+tvNrB9wMzDO3bea2QPEiq86DfXEHYqKeo9r631fyyefuQZ80d2XHeAx97yZ3/f2M7v7bYcatIiIRI96BEVEJKUFs3yWu/tDwF3AGGAnkBPs0pZYsbfdzLoAZ+zjcPWf15h99uV54FozMwAzG72f/U81s47BPYuTgLcb+JnjEZuIiESEegRFRCTVjQTuMrNaoAq4CpgAPGdm69z9RDPLB5YCa4G393GsB4A/mdkuYEIwHHNPf6l/7EOI9yfAb4AFZpYGrALO3sf+s4DpQE/gIXefY2YT+ezPHI/YREQkIrR8hIiISJIys0uILQdxTdixiIhI86KhoSIiIiIiIhGjHkEREZG9MLOZQL89mr/j7s83wWtNBH6+R/Mqdz8v3q8lIiICKgRFREREREQiR0NDRUREREREIkaFoIiIiIiISMSoEBQREREREYkYFYIiIiIiIiIRo0JQREREREQkYv4/jSOJwlkD85sAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 1080x432 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "df_jam_w_time.groupby(['start_time_pst']).size().loc[time_window_start:time_window_end].plot(figsize=(15, 6))\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 691,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "36083"
+      ]
+     },
+     "execution_count": 691,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_time_window = df_jam_time_index.loc[time_window_start:time_window_end]\n",
+    "len(df_time_window)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Trying find outliers in categories of road types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 697,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[1, 2, 3, 4, 6, 7, 17, 20]"
+      ]
+     },
+     "execution_count": 697,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sorted(df.road_type.unique())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 698,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'\\nValue Type\\n1 Streets\\n2 Primary Street\\n3 Freeways\\n4 Ramps\\n5 Trails\\n6 Primary\\n7 Secondary\\n8,14 4X4 Trails\\n15 Ferry crossing\\n9 Walkway\\n10 Pedestrian\\n11 Exit\\n16 Stairway\\n17 Private road\\n18 Railroads\\n19 Runway/Taxiway\\n20 Parking lot road\\n21 Service road\\n'"
+      ]
+     },
+     "execution_count": 698,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "\"\"\"\n",
+    "Provided by WAZE data description\n",
+    "Value Type\n",
+    "1 Streets\n",
+    "2 Primary Street\n",
+    "3 Freeways\n",
+    "4 Ramps\n",
+    "5 Trails\n",
+    "6 Primary\n",
+    "7 Secondary\n",
+    "8,14 4X4 Trails\n",
+    "15 Ferry crossing\n",
+    "9 Walkway\n",
+    "10 Pedestrian\n",
+    "11 Exit\n",
+    "16 Stairway\n",
+    "17 Private road\n",
+    "18 Railroads\n",
+    "19 Runway/Taxiway\n",
+    "20 Parking lot road\n",
+    "21 Service road\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 699,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>jam_id</th>\n",
+       "      <th>datafile_id</th>\n",
+       "      <th>street</th>\n",
+       "      <th>road_type</th>\n",
+       "      <th>delay</th>\n",
+       "      <th>length</th>\n",
+       "      <th>line</th>\n",
+       "      <th>start_time_utc</th>\n",
+       "      <th>end_time_utc</th>\n",
+       "      <th>start_time_pst</th>\n",
+       "      <th>end_time_pst</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1866670844</td>\n",
+       "      <td>501</td>\n",
+       "      <td>Hope St</td>\n",
+       "      <td>7</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>250</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>2017-12-12 15:43:00+00:00</td>\n",
+       "      <td>2017-12-12 15:44:00+00:00</td>\n",
+       "      <td>2017-12-12 07:43:00-08:00</td>\n",
+       "      <td>2017-12-12 07:44:00-08:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1873311008</td>\n",
+       "      <td>501</td>\n",
+       "      <td>Hope St SOUTH</td>\n",
+       "      <td>7</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>153</td>\n",
+       "      <td>[{'x': -118.253027, 'y': 34.054704}, {'x': -11...</td>\n",
+       "      <td>2017-12-12 15:43:00+00:00</td>\n",
+       "      <td>2017-12-12 15:44:00+00:00</td>\n",
+       "      <td>2017-12-12 07:43:00-08:00</td>\n",
+       "      <td>2017-12-12 07:44:00-08:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1873311278</td>\n",
+       "      <td>501</td>\n",
+       "      <td>Aqua Vista St</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>101</td>\n",
+       "      <td>[{'x': -118.3757, 'y': 34.14497}, {'x': -118.3...</td>\n",
+       "      <td>2017-12-12 15:43:00+00:00</td>\n",
+       "      <td>2017-12-12 15:44:00+00:00</td>\n",
+       "      <td>2017-12-12 07:43:00-08:00</td>\n",
+       "      <td>2017-12-12 07:44:00-08:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1879251557</td>\n",
+       "      <td>501</td>\n",
+       "      <td>Aqua Vista St</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>101</td>\n",
+       "      <td>[{'x': -118.37788, 'y': 34.144971}, {'x': -118...</td>\n",
+       "      <td>2017-12-12 15:43:00+00:00</td>\n",
+       "      <td>2017-12-12 15:44:00+00:00</td>\n",
+       "      <td>2017-12-12 07:43:00-08:00</td>\n",
+       "      <td>2017-12-12 07:44:00-08:00</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1867711563</td>\n",
+       "      <td>501</td>\n",
+       "      <td>Aqua Vista St</td>\n",
+       "      <td>2</td>\n",
+       "      <td>-1</td>\n",
+       "      <td>101</td>\n",
+       "      <td>[{'x': -118.37679, 'y': 34.144971}, {'x': -118...</td>\n",
+       "      <td>2017-12-12 15:43:00+00:00</td>\n",
+       "      <td>2017-12-12 15:44:00+00:00</td>\n",
+       "      <td>2017-12-12 07:43:00-08:00</td>\n",
+       "      <td>2017-12-12 07:44:00-08:00</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       jam_id  datafile_id         street  road_type  delay  length  \\\n",
+       "0  1866670844          501        Hope St          7     -1     250   \n",
+       "1  1873311008          501  Hope St SOUTH          7     -1     153   \n",
+       "2  1873311278          501  Aqua Vista St          2     -1     101   \n",
+       "3  1879251557          501  Aqua Vista St          2     -1     101   \n",
+       "4  1867711563          501  Aqua Vista St          2     -1     101   \n",
+       "\n",
+       "                                                line  \\\n",
+       "0  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...   \n",
+       "1  [{'x': -118.253027, 'y': 34.054704}, {'x': -11...   \n",
+       "2  [{'x': -118.3757, 'y': 34.14497}, {'x': -118.3...   \n",
+       "3  [{'x': -118.37788, 'y': 34.144971}, {'x': -118...   \n",
+       "4  [{'x': -118.37679, 'y': 34.144971}, {'x': -118...   \n",
+       "\n",
+       "             start_time_utc              end_time_utc  \\\n",
+       "0 2017-12-12 15:43:00+00:00 2017-12-12 15:44:00+00:00   \n",
+       "1 2017-12-12 15:43:00+00:00 2017-12-12 15:44:00+00:00   \n",
+       "2 2017-12-12 15:43:00+00:00 2017-12-12 15:44:00+00:00   \n",
+       "3 2017-12-12 15:43:00+00:00 2017-12-12 15:44:00+00:00   \n",
+       "4 2017-12-12 15:43:00+00:00 2017-12-12 15:44:00+00:00   \n",
+       "\n",
+       "             start_time_pst              end_time_pst  \n",
+       "0 2017-12-12 07:43:00-08:00 2017-12-12 07:44:00-08:00  \n",
+       "1 2017-12-12 07:43:00-08:00 2017-12-12 07:44:00-08:00  \n",
+       "2 2017-12-12 07:43:00-08:00 2017-12-12 07:44:00-08:00  \n",
+       "3 2017-12-12 07:43:00-08:00 2017-12-12 07:44:00-08:00  \n",
+       "4 2017-12-12 07:43:00-08:00 2017-12-12 07:44:00-08:00  "
+      ]
+     },
+     "execution_count": 699,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_jam_w_time.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 700,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_1 = df_jam_w_time[df_jam_w_time.road_type == 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 701,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_2 = df_jam_w_time[df_jam_w_time.road_type == 2]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 702,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_3 = df_jam_w_time[df_jam_w_time.road_type == 3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 703,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_4 = df_jam_w_time[df_jam_w_time.road_type == 4]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 704,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_6 = df_jam_w_time[df_jam_w_time.road_type == 6]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 705,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_7 = df_jam_w_time[df_jam_w_time.road_type == 7]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 706,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_17 = df_jam_w_time[df_jam_w_time.road_type == 17]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 707,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_roadtype_20 = df_jam_w_time[df_jam_w_time.road_type == 20]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 708,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt1_2std = df_roadtype_1.delay.mean() + 2 * df_roadtype_1.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 709,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt2_2std = df_roadtype_2.delay.mean() + 2 * df_roadtype_2.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 710,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt3_2std = df_roadtype_3.delay.mean() + 2 * df_roadtype_3.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 711,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt4_2std = df_roadtype_4.delay.mean() + 2 * df_roadtype_4.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 712,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt6_2std = df_roadtype_6.delay.mean() + 2 * df_roadtype_6.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 713,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt7_2std = df_roadtype_7.delay.mean() + 2 * df_roadtype_7.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 714,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt17_2std = df_roadtype_17.delay.mean() + 2 * df_roadtype_17.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 715,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "upperbound_delay_rt20_2std = df_roadtype_20.delay.mean() + 2 * df_roadtype_20.delay.std()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 716,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt1 = df_time_window[(df_time_window.road_type == 1) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt1_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 717,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt1.name = \"1-Street\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 718,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt2 = df_time_window[(df_time_window.road_type == 2) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt2_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 719,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt2.name = \"2-Primary Street\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 720,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt3 = df_time_window[(df_time_window.road_type == 3) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt3_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 721,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt3.name = \"3-Freeways\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 722,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt4 = df_time_window[(df_time_window.road_type == 4) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt4_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 723,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt4.name = \"4-Ramps\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 724,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt6 = df_time_window[(df_time_window.road_type == 6) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt6_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 725,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt6.name = \"6-Primary\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 726,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt7 = df_time_window[(df_time_window.road_type == 7) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt7_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 727,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt7.name = \"7-Secondary\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 728,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt17 = df_time_window[(df_time_window.road_type == 17) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt17_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 729,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt17.name = \"17-Private Road\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 730,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt20 = df_time_window[(df_time_window.road_type == 20) & \\\n",
+    "                                    ((df_time_window.delay > upperbound_delay_rt20_2std) | \\\n",
+    "                                     (df_time_window.delay == -1))]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 731,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delay_outliers_rt20.name = \"20-Parking lot road\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 732,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ls_delay_outliers = [delay_outliers_rt1, delay_outliers_rt2, delay_outliers_rt3, delay_outliers_rt4, \n",
+    "                    delay_outliers_rt6, delay_outliers_rt7, delay_outliers_rt17, delay_outliers_rt20]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 792,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# make a helper function that will make the input for graph making tool\n",
+    "def getGeoJson(lines):\n",
+    "    count=0\n",
+    "    feature_coll = []\n",
+    "    p = {'sample': 450, 'weight': 1.5}\n",
+    "    for line in lines:\n",
+    "        points = []\n",
+    "        line = eval(line)\n",
+    "        for point in line:\n",
+    "            points.append((point['x'], point['y']))\n",
+    "        feature_coll.append(Feature(geometry=LineString(points), properties=p))\n",
+    "    return FeatureCollection(feature_coll)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 805,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_in_map(df):\n",
+    "    if len(df)==0:\n",
+    "        print(f\"No outliers found for {df.name}\")\n",
+    "        return\n",
+    "    print(df.name)\n",
+    "    viz = LinestringViz(getGeoJson(df.line), \n",
+    "                        access_token=token,\n",
+    "                        color_property='sample',\n",
+    "                        color_stops=create_color_stops([0, 350, 400, 500, 600], colors='Reds'),\n",
+    "                        line_stroke='--',\n",
+    "                        line_width_property='weight',\n",
+    "                        line_width_stops=create_numeric_stops([0, 1, 2, 3, 4, 5], 0, 10),\n",
+    "                        opacity=0.8,\n",
+    "                        center = (-118.2427, 34.0537),\n",
+    "                        zoom = 9,\n",
+    "                        below_layer='waterway-label')\n",
+    "#     viz.show()\n",
+    "    html = open(f\"/tmp/{df.name}-outliers.html\", \"w\")\n",
+    "    html.write( viz.create_html() )\n",
+    "    html.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 806,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1-Street\n",
+      "2-Primary Street\n",
+      "3-Freeways\n",
+      "4-Ramps\n",
+      "6-Primary\n",
+      "7-Secondary\n",
+      "No outliers found for 17-Private Road\n",
+      "No outliers found for 20-Parking lot road\n"
+     ]
+    }
+   ],
+   "source": [
+    "for x in ls_delay_outliers:\n",
+    "    show_in_map(x)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### And we can get to know which streets actually have jams"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 766,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array(['to I-405 S / Long Beach', 'to Sherman Way - W', nan,\n",
+       "       'to I-405 N / Sacramento', 'to Glendale Blvd - South',\n",
+       "       'to I-405 N', 'Exit 134A: Soto St', 'Exit 1D: Soto St',\n",
+       "       'to US-101 N / Ventura', 'to I-405 S / Santa Monica',\n",
+       "       'to Santa Fe Ave', 'to Hoover St', 'Exit 140A: Fletcher Dr',\n",
+       "       'Exit 48: La Tijera Blvd', 'Exit 55B: Wilshire Blvd E'],\n",
+       "      dtype=object)"
+      ]
+     },
+     "execution_count": 766,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "delay_outliers_rt4.street.unique()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/dags/waze/dag-Traffic-Jam-Outlier-Detector-WAZE-data.py
+++ b/dags/waze/dag-Traffic-Jam-Outlier-Detector-WAZE-data.py
@@ -1,0 +1,343 @@
+import os
+import numpy as np
+import pandas as pd
+from sqlalchemy import create_engine
+from mapboxgl.viz import LinestringViz
+from mapboxgl.utils import create_color_stops, create_numeric_stops
+from geojson import Feature, FeatureCollection, LineString
+
+import logging
+import airflow
+from datetime import datetime, timedelta
+#from dateutil.relativedelta import relativedelta
+from pytz import timezone
+from airflow.operators.python_operator import PythonOperator
+from airflow.operators.postgres_operator import PostgresOperator
+from airflow.utils.email import send_email
+from airflow.models import Variable
+
+#categoried by road_types. from 10mil rows of data, outlier upperbounds -- mean+2std:
+upperbound_delay_rt1_2std = 364.2580985017166 
+upperbound_delay_rt2_2std = 416.00629003480043
+upperbound_delay_rt3_2std = 1337.7260891639444
+upperbound_delay_rt4_2std = 393.1583664937325
+upperbound_delay_rt6_2std = 494.9713645058797
+upperbound_delay_rt7_2std = 366.12815975980857
+upperbound_delay_rt17_2std = -1.0
+upperbound_delay_rt20_2std = -1.0
+
+message = f"This Today's Traffic Jam Outliers during 5pm-6pm by Road Type categories:"
+email_to = "hunter.owens@lacity.org" 
+email_cc = "lei.cao@lacity.org"
+subject = "[Alert] Today's Traffic Jam Outliers"
+
+# Mapbox token
+token = os.getenv('MAPBOX_ACCESS_TOKEN')
+
+# Postgres Database login info
+USER = os.getenv('WAZE_USER')
+PASS = os.getenv('WAZE_PASS')
+
+# Remote Database Info
+HOST = 'datalake.cyuk6whwgqww.us-west-2.rds.amazonaws.com'
+PORT = '5432'
+DB = 'db_datalake'
+
+uri = f'postgresql://{USER}:{PASS}@{HOST}:{PORT}/{DB}'
+engine = create_engine(uri)
+
+
+def retrieve_data(**kwarg):
+    """
+    For now, just read the 10mil-row csv. 
+    When we have new data from WAZE, this part will be the data in the time window only
+    """
+    logging.info("start loading jams dataset from remote")
+    # df = pd.read_sql_query("select * from waze.jams limit 10000000",con=engine)
+    # df.to_csv("/tmp/waze.jams_10mil.csv")
+    logging.info("jams dataset is saved to /tmp/waze.jams_10mil.cs")
+
+    logging.info("start loading data_files dataset from remote")
+    df_datafiles = pd.read_sql_query("select * from waze.data_files;", con=engine)
+    df_datafiles.to_csv("/tmp/waze.datafiles.csv", index=False)
+    logging.info("data_files dataset is saved to /tmp/waze.datafiles.csv")
+
+    # clean and leave only what we need
+    df_datafiles = df_datafiles[['id', 'start_time', 'end_time']]
+
+
+def detect_outliers(**kwarg):
+    logging.info('Loading the datasets...')
+    df = pd.read_csv('/tmp/waze.jams_10mil.csv')
+    df_datafiles = pd.read_csv('/tmp/waze.datafiles.csv')
+    logging.info('Loading completed! Starting Detection...')
+
+    # Check LA city ONLY
+    df = df[df.city == 'Los Angeles, CA']
+
+    # add time info to jams data
+    df_jam_w_time = pd.merge(df[['id', 'datafile_id', 'street', 'road_type', 'delay', 'length', 'line']], df_datafiles, left_on='datafile_id', right_on='id')
+    df_jam_w_time.drop(columns=['id_y'], inplace=True)
+    df_jam_w_time.rename({'id_x':'jam_id'}, axis='columns', inplace=True)
+
+    # We don't actually need 'end_time' column. In production, we can drop this column
+    df_jam_w_time['start_time'] = pd.to_datetime(df_jam_w_time['start_time'])
+    # df_jam_w_time['end_time'] = pd.to_datetime(df_jam_w_time['end_time'])
+
+    # Add time zone info
+    df_jam_w_time['start_time'] = df_jam_w_time['start_time'].apply(timezone('UTC').localize)
+    # df_jam_w_time['end_time'] = df_jam_w_time['end_time'].apply(timezone('UTC').localize)
+    df_jam_w_time.rename({'start_time':'start_time_utc', 'end_time':'end_time_utc'}, axis='columns', inplace=True)
+
+    logging.info('In Progress...')
+
+    # Adding PST timezone
+    df_jam_w_time['start_time_pst'] = df_jam_w_time['start_time_utc'].apply(lambda x: x.astimezone(timezone('US/Pacific')))
+    # df_jam_w_time['end_time_pst'] = df_jam_w_time['end_time_utc'].apply(lambda x: x.astimezone(timezone('US/Pacific')))
+
+    logging.info('In Progress...')
+
+    # Delay Outliers in a time window
+    # Check a time window on a Friday afternoon
+
+    df_jam_time_index = df_jam_w_time.set_index('start_time_pst', drop=False)
+    df_jam_time_index.sort_index(inplace=True)
+
+    # set the time window
+    time_window_start = datetime(2017, 12, 15, 17,0,0, tzinfo=timezone('US/Pacific'))
+    time_window_end = datetime(2017, 12, 15, 18,0,0, tzinfo=timezone('US/Pacific'))
+
+    df_time_window = df_jam_time_index.loc[time_window_start:time_window_end]
+
+    if len(df_time_window) == 0:
+        logging.info('No data available in the given Time Window')
+        return
+
+    # Get outliers in categories of road types
+    """
+    Road Types - provided by WAZE data description
+
+    Value Type
+    1 Streets
+    2 Primary Street
+    3 Freeways
+    4 Ramps
+    5 Trails            -- NA in the dataset
+    6 Primary
+    7 Secondary
+    8,14 4X4 Trails     -- NA in the dataset
+    15 Ferry crossing   -- NA in the dataset
+    9 Walkway           -- NA in the dataset
+    10 Pedestrian       -- NA in the dataset
+    11 Exit             -- NA in the dataset
+    16 Stairway         -- NA in the dataset
+    17 Private road
+    18 Railroads        -- NA in the dataset
+    19 Runway/Taxiway   -- NA in the dataset
+    20 Parking lot road
+    21 Service road     -- NA in the dataset
+    """
+
+    df_roadtype_1 = df_jam_w_time[df_jam_w_time.road_type == 1]
+    df_roadtype_2 = df_jam_w_time[df_jam_w_time.road_type == 2]
+    df_roadtype_3 = df_jam_w_time[df_jam_w_time.road_type == 3]
+    df_roadtype_4 = df_jam_w_time[df_jam_w_time.road_type == 4]
+    df_roadtype_6 = df_jam_w_time[df_jam_w_time.road_type == 6]
+    df_roadtype_7 = df_jam_w_time[df_jam_w_time.road_type == 7]
+    df_roadtype_17 = df_jam_w_time[df_jam_w_time.road_type == 17]
+    df_roadtype_20 = df_jam_w_time[df_jam_w_time.road_type == 20]
+
+    # The Outlier Upperbounds are calculated and stored as variables at the top
+
+    # upperbound_delay_rt1_2std = df_roadtype_1.delay.mean() + 2 * df_roadtype_1.delay.std()
+    # upperbound_delay_rt2_2std = df_roadtype_2.delay.mean() + 2 * df_roadtype_2.delay.std()
+    # upperbound_delay_rt3_2std = df_roadtype_3.delay.mean() + 2 * df_roadtype_3.delay.std()
+    # upperbound_delay_rt4_2std = df_roadtype_4.delay.mean() + 2 * df_roadtype_4.delay.std()
+    # upperbound_delay_rt6_2std = df_roadtype_6.delay.mean() + 2 * df_roadtype_6.delay.std()
+    # upperbound_delay_rt7_2std = df_roadtype_7.delay.mean() + 2 * df_roadtype_7.delay.std()
+    # upperbound_delay_rt17_2std = df_roadtype_17.delay.mean() + 2 * df_roadtype_17.delay.std()
+    # upperbound_delay_rt20_2std = df_roadtype_20.delay.mean() + 2 * df_roadtype_20.delay.std()
+
+    #
+    delay_outliers_rt1 = df_time_window[(df_time_window.road_type == 1) &                                     
+                                        ((df_time_window.delay > upperbound_delay_rt1_2std) |                                     
+                                        (df_time_window.delay == -1))]
+    delay_outliers_rt1.name = "1-Street"
+
+    delay_outliers_rt2 = df_time_window[(df_time_window.road_type == 2) &                                    
+                                        ((df_time_window.delay > upperbound_delay_rt2_2std) |                                      
+                                        (df_time_window.delay == -1))]
+    delay_outliers_rt2.name = "2-Primary Street"
+
+    delay_outliers_rt3 = df_time_window[(df_time_window.road_type == 3) &                                     
+                                        ((df_time_window.delay > upperbound_delay_rt3_2std) |                                      
+                                        (df_time_window.delay == -1))]
+    delay_outliers_rt3.name = "3-Freeways"
+
+    delay_outliers_rt4 = df_time_window[(df_time_window.road_type == 4) &                                     
+                                        ((df_time_window.delay > upperbound_delay_rt4_2std) |                                      
+                                        (df_time_window.delay == -1))]
+    delay_outliers_rt4.name = "4-Ramps"
+
+    delay_outliers_rt6 = df_time_window[(df_time_window.road_type == 6) &                                     
+                                        ((df_time_window.delay > upperbound_delay_rt6_2std) |                                      
+                                        (df_time_window.delay == -1))]
+    delay_outliers_rt6.name = "6-Primary"
+
+    delay_outliers_rt7 = df_time_window[(df_time_window.road_type == 7) &                                     
+                                        ((df_time_window.delay > upperbound_delay_rt7_2std) |                                      
+                                        (df_time_window.delay == -1))]
+    delay_outliers_rt7.name = "7-Secondary"
+
+    delay_outliers_rt17 = df_time_window[(df_time_window.road_type == 17) &                                     
+                                         ((df_time_window.delay > upperbound_delay_rt17_2std) |                                      
+                                         (df_time_window.delay == -1))]
+    delay_outliers_rt17.name = "17-Private Road"
+
+    delay_outliers_rt20 = df_time_window[(df_time_window.road_type == 20) &                                     
+                                         ((df_time_window.delay > upperbound_delay_rt20_2std) |                                      
+                                         (df_time_window.delay == -1))]
+    delay_outliers_rt20.name = "20-Parking lot road"
+
+    ls_delay_outliers = [delay_outliers_rt1, delay_outliers_rt2, delay_outliers_rt3, delay_outliers_rt4, 
+                        delay_outliers_rt6, delay_outliers_rt7, delay_outliers_rt17, delay_outliers_rt20]
+
+    # make a helper function that will make the input for graph making tool
+    def getGeoJson(lines):
+        count=0
+        feature_coll = []
+        p = {'sample': 450, 'weight': 1.5}
+        for line in lines:
+            points = []
+            line = eval(line)
+            for point in line:
+                points.append((point['x'], point['y']))
+            feature_coll.append(Feature(geometry=LineString(points), properties=p))
+        return FeatureCollection(feature_coll)
+
+    # function that make map and save as html
+    def show_in_map(df):
+        
+        logging.info(df.name)
+        viz = LinestringViz(getGeoJson(df.line), 
+                            access_token=token,
+                            color_property='sample',
+                            color_stops=create_color_stops([0, 350, 400, 500, 600], colors='Reds'),
+                            line_stroke='--',
+                            line_width_property='weight',
+                            line_width_stops=create_numeric_stops([0, 1, 2, 3, 4, 5], 0, 10),
+                            opacity=0.8,
+                            center = (-118.2427, 34.0537),
+                            zoom = 9,
+                            below_layer='waterway-label')
+        # viz.show()
+        html = open(f"/tmp/{df.name}-outliers.html", "w")
+        html.write(viz.create_html())
+        html.close()
+        return f"/tmp/{df.name}-outliers.html"
+
+    logging.info('Making Maps ...')
+
+    # a dict to hold the outlier street names
+    outliers = {}
+
+    # make and save map
+    for x in ls_delay_outliers:
+        if len(x) != 0:
+            logging.info(f"Outliers found for {x.name}")
+            outliers[x.name] = [show_in_map(x)]
+            outliers[x.name].append(x.street.unique())
+        else:
+            logging.info(f"No outliers found for {x.name}")
+    
+
+    return outliers
+
+
+def sendemail(to_addr_list, cc_addr_list, subject,
+              message, **kwargs):
+    # xcom_pull alert from last task's return value
+    task_instance = kwargs['task_instance']
+    outliers = task_instance.xcom_pull(task_ids='detect_outliers')
+              
+    # if no outliers found, skip sending email
+    if bool(outliers):
+        # prepare email body
+
+        files = []
+        for key, value in outliers.items():
+            files.append(value[0])
+
+        html_content = make_html_content(outliers, message)
+        send_email(to_addr_list, subject, html_content,
+               files=files,  cc=cc_addr_list)
+        return "Outliers founded. Alert Email sent. Success!"
+
+    return "No alert generated. Email not sent."
+
+
+def make_html_content(outliers, message):
+    count = 1
+    c = message.join(['<br><b>', '</b></br><br />'])
+    for key, value in outliers.items():
+        c += f"{key}:{value[1]}<br/><br/>"
+        count += 1
+    return c
+
+
+def remove_map_html(**kwargs):
+    task_instance = kwargs['task_instance']
+    outliers = task_instance.xcom_pull(task_ids='detect_outliers')
+
+    for key, value in outliers.items():
+        file = value[0]
+        if os.path.exists(file):
+          os.remove(file)
+        else:
+          print("The file "+ file + " does not exist. Skipping to the next map html")
+
+
+# airflow DAG arguments
+args = {'owner': 'hunterowens',
+    'start_date': airflow.utils.dates.days_ago(7),
+    'provide_context': True,
+    'email': 'hunter.owens@lacity.org',
+    'email_on_failure': False,
+    'retries': 1, 
+    'retry_delay': timedelta(minutes=5)
+    }
+
+# initiating the DAG
+dag = airflow.DAG(
+    dag_id='traffic-jam-outlier_detector',
+    schedule_interval="@daily",
+    default_args=args,
+    max_active_runs=1)
+
+task0 = PythonOperator(
+    task_id='retrieve_data',
+    provide_context=True,
+    python_callable=retrieve_data,
+    dag=dag)
+
+task1 = PythonOperator(
+    task_id='detect_outliers',
+    provide_context=True,
+    python_callable=detect_outliers,
+    dag=dag)
+
+task2 = PythonOperator(
+    task_id='send_email_if_outliers',
+    provide_context=True,
+    # all the variable used below should be setup as environment variable
+    op_args=[email_to, email_cc, subject, message],
+    python_callable=sendemail,
+    dag=dag)
+
+task3 = PythonOperator(
+    task_id='remove_map_html',
+    provide_context=True,
+    python_callable=remove_map_html,
+    dag=dag)
+
+task0 >> task1 >> task2 >> task3


### PR DESCRIPTION
DAG and Notebook

Waze data uses UTC timezone. The proof is provided in the Notebook. The Detection uses PST Los Angeles local time. 

