### PR TITLE
waze reduce scheduler overhead

### DIFF
--- a/dags/transportation/waze/dag-waze-dataProcessor.py
+++ b/dags/transportation/waze/dag-waze-dataProcessor.py
@@ -339,7 +339,8 @@ def processJSONtoDB(**kwargs):
 				irregs_tosql.to_sql(name="irregularities", schema=schemaName, con=meta.bind, if_exists="append", index=False,
 						    dtype={"line": typeJSON})
 
-			print("File added to database! ")
+                        #finished processing file
+                        print("File added to database! ")
 			processedKeys.append(key)
 			
 			# store file info before deleting key
@@ -354,7 +355,7 @@ def processJSONtoDB(**kwargs):
 			
 			# how many files to process, comment out to process all files
 			count += 1
-			if count > 0:
+			if count > 5:
 				break
 			
 	print ("processed keys:")
@@ -397,6 +398,7 @@ def moveProcessedKeys(**kwargs):
 			
 	logging.info("moveProcessedKeys complete!")
 
+''' removed as unnecessary and time consuming
 s3keySense = S3KeySensor(
 	task_id='s3_file_test',
 	poke_interval=15, #retry after 15 seconds
@@ -407,7 +409,7 @@ s3keySense = S3KeySensor(
 	bucket_name="{{ var.value.waze_s3_bucket_source }}",
 	aws_conn_id='s3_conn',
 	dag=dag)
-
+'''
 
 #emailNotify = EmailOperator(
 #   task_id='email_notification',
@@ -434,4 +436,4 @@ moveProcessedFilesOp = PythonOperator(
 	dag=dag)
 	
 # order of execution of tasks
-dag >> s3keySense >> processDataFileOp >> moveProcessedFilesOp
+dag >> processDataFileOp >> moveProcessedFilesOp

--- a/dags/transportation/waze/dag-waze-dataProcessor.py
+++ b/dags/transportation/waze/dag-waze-dataProcessor.py
@@ -339,8 +339,8 @@ def processJSONtoDB(**kwargs):
 				irregs_tosql.to_sql(name="irregularities", schema=schemaName, con=meta.bind, if_exists="append", index=False,
 						    dtype={"line": typeJSON})
 
-                        #finished processing file
-                        print("File added to database! ")
+			#finished processing file
+			print("File added to database! ")
 			processedKeys.append(key)
 			
 			# store file info before deleting key

--- a/dags/transportation/waze/dag-waze-dataProcessor.py
+++ b/dags/transportation/waze/dag-waze-dataProcessor.py
@@ -65,19 +65,6 @@ def s3keyCheck():
 	else:
 		logging.info("no key found")
 		return False
-        
-#       session = boto3.Session(
-#	s3 = boto3.resource('s3')
-#	client = boto3.client('s3')
-#	bucket_source = s3.Bucket(bucket_source_name)
-#	objs = client.list_objects_v2(Bucket='bucket_source_name',MaxKeys=1)
-#	if (objs['KeyCount'] > 0):
-#		print ('Found at least 1 key!')
-#		logging.info("found at least 1 key")
-#		return True
-#	else:
-#		logging.info("no keys found")
-#		return False
 
 def logTest():
 	logging.info('logTest called')
@@ -99,7 +86,6 @@ def connect_database(connection_id):
 	return meta
 
 def tab_raw_data(s3_key_obj):
-
 	#read data file
 	#doc = open(datafile_s3_key) # old local file method
 	# get file from S3
@@ -419,42 +405,11 @@ def moveProcessedKeys(**kwargs):
 			
 	logging.info("moveProcessedKeys complete!")
 
-''' removed as unnecessary and time consuming
-s3keySense = S3KeySensor(
-	task_id='s3_file_test',
-	poke_interval=15, #retry after 15 seconds
-	timeout=60, #timeout after 60 seconds
-	soft_fail=True, #mark task Skipped on failure
-	bucket_key='*',
-	wildcard_match=True,
-	bucket_name="{{ var.value.waze_s3_bucket_source }}",
-	aws_conn_id='s3_conn',
-	dag=dag)
-'''
-
-#emailNotify = EmailOperator(
-#   task_id='email_notification',
-#   to = 'bryan.blackford@lacity.org',
-#   subject = 'ETL Job Done',
-#   html_content = 'Airflow ETL Job Done',
-#   dag=dag)
-
-#s3keyCheckOp = PythonOperator(
-#        task_id='s3keyCheckOpID',
-#        python_callable=s3keyCheck,
-#        dag=dag)
-
 processDataFileOp = PythonOperator(
 	task_id='processDataFile',
 	python_callable=processJSONtoDB,
 	provide_context=True,
 	dag=dag)
-'''
-moveProcessedFilesOp = PythonOperator(
-	task_id='moveProcessedKeys',
-	python_callable=moveProcessedKeys,
-	provide_context=True,
-	dag=dag)
-'''	
+
 # order of execution of tasks
 dag >> processDataFileOp

--- a/dags/transportation/waze/dag-waze-dataProcessor.py
+++ b/dags/transportation/waze/dag-waze-dataProcessor.py
@@ -236,8 +236,8 @@ def tab_alerts(raw_data):
 
 def processJSONtoDB(**kwargs):
 	logging.info("processJSONtoDB called")
+	# get schema name from airflow variables
 	schemaName = Variable.get("waze_db_schema")
-	bucket_source_name = Variable.get("waze_s3_bucket_source")
 	
 	logging.info("Connecting to database. schema="+schemaName)
 	meta = connect_database("postgres_default") #"aws_postgres_datalake")
@@ -258,12 +258,14 @@ def processJSONtoDB(**kwargs):
 	logging.info("Got S3 Hook")
 
 	# get bucket names and bucket for moving files from queued to processed
-	bucket_source_name = Variable.get("waze_s3_bucket_source")
 	bucket_processed_name = Variable.get("waze_s3_bucket_processed")
+	bucket_source_name = Variable.get("waze_s3_bucket_source")
 	#bucket_source = s3.Bucket(bucket_source_name)
 	bucket_processed = hook.get_bucket(bucket_processed_name)
-
-        #key = hook.get_wildcard_key(wildcard_key="*",bucket_name=bucket_source_name)
+	# files processed per run
+	process_files_per_run = int(Variable.get("waze_process_files_per_run"))
+	
+	#key = hook.get_wildcard_key(wildcard_key="*",bucket_name=bucket_source_name)
 	#print ("Got a key from S3 bucket:")
 	#print (key.key)
 
@@ -373,7 +375,7 @@ def processJSONtoDB(**kwargs):
 			
 			# how many files to process, comment out to process all files
 			count += 1
-			if count > 5:
+			if count >= process_files_per_run:
 				break
 			
 	#print ("processed keys:")


### PR DESCRIPTION
This works to address issue #56 by reducing the dag to a single task, reducing scheduler overhead (delays between task runs). 
1. eliminating s3 key test, which isn't necessary; when s3 bucket is empty, the main task will quietly do nothing. 
2. moving the s3 key move from the 3rd task into the main task.
3. each run processes 6 files instead of 1. This number is now controlled by the airflow var: waze_process_files_per_run. 