### PR TITLE
override default version with configfile version

### DIFF
--- a/dags/transportation/dockless/dockless_elt.py
+++ b/dags/transportation/dockless/dockless_elt.py
@@ -122,13 +122,15 @@ def load_to_s3(**kwargs):
     config = mds.ConfigFile('/tmp/config.json', company)
     logging.info("Downloaded and parsed config from S3")
     # assert the version parameter
-    version = '0.3.2'
+    if config.version: 
+        version = config.version
+    else: 
+        version = '0.3.2'
     # set company 
     logging.info(f"set company to {company}")
     logging.info(f"Referencing MDS @ {version}")
     # load company
-    client = mds.Client(company, config,
-                        version=version)
+    client = mds.Client(company, config, version)
     end_time = kwargs['execution_date']
     ## test is provider is jump, up hours because their ETL is slow. 
     if client.provider.provider_id == 'c20e08cf-8488-46a6-a66c-5d8fb827f7e0': 

--- a/dags/transportation/dockless/dockless_elt.py
+++ b/dags/transportation/dockless/dockless_elt.py
@@ -122,9 +122,10 @@ def load_to_s3(**kwargs):
     config = mds.ConfigFile('/tmp/config.json', company)
     logging.info("Downloaded and parsed config from S3")
     # assert the version parameter
-    if config.version: 
+    try: 
+        config.version 
         version = config.version
-    else: 
+    except AttributeError: 
         version = '0.3.2'
     # set company 
     logging.info(f"set company to {company}")

--- a/dags/transportation/dockless/dockless_elt.py
+++ b/dags/transportation/dockless/dockless_elt.py
@@ -130,7 +130,8 @@ def load_to_s3(**kwargs):
     logging.info(f"set company to {company}")
     logging.info(f"Referencing MDS @ {version}")
     # load company
-    client = mds.Client(company, config, version)
+    client = mds.Client(company, config, 
+                        version=version)
     end_time = kwargs['execution_date']
     ## test is provider is jump, up hours because their ETL is slow. 
     if client.provider.provider_id == 'c20e08cf-8488-46a6-a66c-5d8fb827f7e0': 

--- a/dags/transportation/dockless/dockless_elt.py
+++ b/dags/transportation/dockless/dockless_elt.py
@@ -122,11 +122,7 @@ def load_to_s3(**kwargs):
     config = mds.ConfigFile('/tmp/config.json', company)
     logging.info("Downloaded and parsed config from S3")
     # assert the version parameter
-    try: 
-        config.version 
-        version = config.version
-    except AttributeError: 
-        version = '0.3.2'
+    version = getattr(config, 'version', '0.3.2')
     # set company 
     logging.info(f"set company to {company}")
     logging.info(f"Referencing MDS @ {version}")


### PR DESCRIPTION
if we put a `version` in the config file, use that instead of the default. good for JUMP and Spin rn . 