### PR TITLE
RATSTAT DAG 

### DIFF
--- a/dags/public-health/ratstat.py
+++ b/dags/public-health/ratstat.py
@@ -1,0 +1,24 @@
+import arcgis 
+import os 
+
+def ratstat_loader():
+    """
+    load the ratstat data 
+    into a postgres DB
+    """ 
+    hub = arcgis.gis.GIS(url='https://lahub.maps.arcgis.com',
+                         username=os.environ.get('LAHUB_USERNAME'),
+                         password=os.environ.get('LAHUB_PASSWORD'))
+    rat_stat_group = arcgis.gis.Group(hub, 
+                                      '7f3d66478dd846598e76a8e334a03988') #this is the groupid of the ratstat group       
+    content = rat_stat_group.content()
+    feature_layers = []
+    for item in content:
+        try:
+            [feature_layers.append(feature_layer) for feature_layer in item.layers]
+        except KeyError: 
+            pass
+    dfs = [layer.query(as_df=True) for layer in feature_layers]
+                 
+if __name__ == '__main__': 
+    content = ratstat_loader()

--- a/dags/public-health/ratstat.py
+++ b/dags/public-health/ratstat.py
@@ -8,16 +8,24 @@ from datetime import datetime, timedelta
 import logging
 pg_conn = BaseHook.get_connection('postgres_default') 
 
+
+RAT_STAT_ID = "9e7caafab26b490e8ad7f02e5518758c"
+
 def ratstat_loader():
     """
     load the ratstat data 
     into a postgres DB
     """ 
-    hub = arcgis.gis.GIS(url='https://lahub.maps.arcgis.com',
-                         username=os.environ.get('LAHUB_USERNAME'),
-                         password=os.environ.get('LAHUB_PASSWORD'))
-    rat_stat_group = arcgis.gis.Group(hub, 
-                                      '7f3d66478dd846598e76a8e334a03988') #this is the groupid of the ratstat group       
+
+
+    arcconnection = BaseHook.get_connection("arcgis")
+    arcuser = arcconnection.login
+    arcpassword = arcconnection.password
+    gis = arcgis.gis.GIS(url='https://lahub.maps.arcgis.com',
+                         username=arcuser,
+                         password=arcpassword))
+    rat_stat_group = arcgis.gis.Group(gis, 
+                                      RAT_STAT_ID) #this is the groupid of the ratstat group       
     logging.info("Logged into hub and accessed rat stat group.")
     content = rat_stat_group.content()
     feature_layers = []

--- a/dags/public-health/ratstat.py
+++ b/dags/public-health/ratstat.py
@@ -3,6 +3,8 @@ import os
 from sqlalchemy import create_engine
 from airflow import DAG
 from airflow.operators.python_operator import PythonOperator
+from datetime import datetime, timedelta
+
 
 def ratstat_loader():
     """

--- a/dags/public-health/ratstat.py
+++ b/dags/public-health/ratstat.py
@@ -31,7 +31,8 @@ def ratstat_loader():
     feature_layers = []
     for item in content:
         try:
-            [feature_layers.append(feature_layer) for feature_layer in item.layers]
+            for layer in item.layers:
+                feature_layers.append(layer)
         except KeyError: 
             pass
     dfs = {layer.properties['name']: layer.query(as_df=True, as_shapely=True) for layer in feature_layers}

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ html5lib
 requests
 pyarrow
 s3fs
+arcgis


### PR DESCRIPTION
currently, Rat trap statistic information is kept in a group on ArcGIS via the ESRI collector app. 

This DAG pulls the data nightly and replaces it in the `public-health` schema of the data warehouse. 

