### PR TITLE
Airflow reqs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,10 +51,14 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install Python dependencies
+COPY airflow-requirements.txt /tmp/
 COPY requirements.txt /tmp/
 # Switch to /tmp to install dependencies outside home dir
 WORKDIR /tmp
 
+# Install airflow requirements separately to avoid inadvertently upgrading them
+# upon deoployment.
+RUN pip install --no-cache-dir -r airflow-requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Switch back to home directory

--- a/airflow-requirements.txt
+++ b/airflow-requirements.txt
@@ -1,0 +1,4 @@
+apache-airflow[celery,postgres,hive,hdfs,jdbc,async,password,crypto,github_enterprise,datadog,statsd,s3]
+redis
+hiredis
+Werkzeug

--- a/appspec.yml
+++ b/appspec.yml
@@ -4,6 +4,11 @@ files:
   - source: /
     destination: /home/ec2-user/aqueduct
     overwrite: yes
+permissions:
+  - object: /home/ec2-user/aqueduct
+    pattern: "**"
+    owner: ec2-user
+    type: directory
 hooks:
   AfterInstall:
     - location: scripts/install.sh

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,5 @@
-Werkzeug
-redis
-hiredis
 sodapy
 boto3
-apache-airflow[celery,postgres,hive,hdfs,jdbc,async,password,crypto,github_enterprise,datadog,statsd,s3]
 matplotlib
 seaborn
 altair


### PR DESCRIPTION
Fixes #86, also makes `ec2-user` an owner on the `aqueduct` directory. It was previously root, the default user that codedeploy uses. This should help with some persistent permissions issues (e.g., cloning editable installs, writing temporary files).