### PR TITLE
Make another cast due to failing upload from type mismatch. Long term,

### DIFF
--- a/dags/transportation/dockless/dockless_elt.py
+++ b/dags/transportation/dockless/dockless_elt.py
@@ -153,6 +153,7 @@ def normalize_trips(df, version):
         "parking_verification_url": str,
         "standard_cost": float, # pandas doesn't yet have nullable integers
         "actual_cost": float, # pandas doesn't yet have nullable integers
+        "trip_distance": float, # pandas doesn't yet have nullable integers
     }
     if version >= Version("0.3.0"):
         types["publication_time"] = float # pandas doesn't yet have nullable integers


### PR DESCRIPTION
the pandas ingest in mds-provider should have *much* stricter type
safety.