### PR TITLE
Add another postgres container for the default analytics database.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,12 @@ services:
   db:
     image: postgres:9.6
 
+  postgres-default:
+    image: postgres:9.6
+    environment:
+      - POSTGRES_USER=ita
+      - POSTGRES_PASSWORD=secret
+
   redis:
     image: redis:3.2
 
@@ -15,6 +21,8 @@ services:
     volumes:
       - $PWD:/app
     command: "true"
+    environment:
+      - AIRFLOW_CONN_POSTGRES_DEFAULT=postgres://ita:secret@postgres-default:5432/ita
 
   web:
     extends:
@@ -25,6 +33,7 @@ services:
       - app
     links:
       - db
+      - postgres-default
       - redis
     command: web
 
@@ -45,6 +54,7 @@ services:
       service: app
     links:
       - db
+      - postgres-default
       - redis
     command: scheduler
 


### PR DESCRIPTION
Hopefully this will make it a bit easier to spin up a dev environment.

We should also document how to add more connections on startup via a `.env` file.