### PR TITLE
Drop null trip IDs in Dash data.

### DIFF
--- a/dags/transportation/dash/trips.py
+++ b/dags/transportation/dash/trips.py
@@ -126,6 +126,10 @@ def load_pg_data(ds, **kwargs):
     # Drop unnecesary driver info.
     df = df.drop(columns=["driver_first_name", "driver_last_name"])
 
+    # Drop null trip ids and make sure they are integers.
+    df = df.dropna(subset=["trip_id"])
+    df.trip_id = df.trip_id.astype("int64")
+
     # Set the timezone to local time with TZ info
     for col in time_cols:
         df[col] = df[col].dt.tz_localize("UTC").dt.tz_convert(LOCAL_TIMEZONE)


### PR DESCRIPTION
Once again, bitten by pandas lacking nullable integers.

Nullable integers are available in more recent versions of pandas, but I want to handle that in a follow-up. In this case, I am treating this a column as a primary key, and think it's fair to drop the few records that don't include it.