### PR TITLE
Coerce types on pre-transformed column names.

### DIFF
--- a/dags/transportation/dash/trips.py
+++ b/dags/transportation/dash/trips.py
@@ -9,6 +9,7 @@ from datetime import datetime, timedelta
 import pandas
 import requests
 import sqlalchemy
+
 from airflow import DAG
 from airflow.hooks.postgres_hook import PostgresHook
 from airflow.hooks.S3_hook import S3Hook
@@ -82,6 +83,10 @@ def check_columns(table, df):
     }
     for column in table.columns:
         assert column.name in df.columns
+        logging.info(
+            f"Checking that {column.name}'s type {column.type} "
+            f"is consistent with {df.dtypes[column.name]}"
+        )
         assert type_map[str(column.type)] == str(df.dtypes[column.name])
 
 
@@ -137,7 +142,7 @@ def load_pg_data(ds, **kwargs):
     check_columns(dash_trips, df)
 
     # Upload the final dataframe to Postgres. Since pandas timestamps conform to the
-    # datetime interfaace, psycopg can correctly handle the timestamps upon insert.
+    # datetime interface, psycopg can correctly handle the timestamps upon insert.
     logging.info("Uploading to PG")
     engine = PostgresHook.get_hook(POSTGRES_ID).get_sqlalchemy_engine()
     insert = sqlalchemy.dialects.postgresql.insert(dash_trips).on_conflict_do_nothing()


### PR DESCRIPTION
Fixes a bug where the wrong column name was used in a type coercion. Pandas should really warn you if you try to coerce types on non-existent columns :/