### PR TITLE
Dockless view refactor

### DIFF
--- a/dags/transportation/dockless/dockless_elt.py
+++ b/dags/transportation/dockless/dockless_elt.py
@@ -272,7 +272,7 @@ CREATE TABLE IF NOT EXISTS status_changes (
     battery_pct FLOAT,
     associated_trip UUID
 );
-ALTER TABLE status_changes DROP CONSTRAINT unique_event;
+ALTER TABLE status_changes DROP CONSTRAINT IF EXISTS unique_event;
 ALTER TABLE status_changes
     ADD CONSTRAINT  unique_event
     UNIQUE (provider_id,

--- a/dags/transportation/dockless/indexes.sql
+++ b/dags/transportation/dockless/indexes.sql
@@ -1,0 +1,39 @@
+-- Indexes for the MDS trips and status changes tables.
+
+ALTER TABLE public.trips_geoms
+    DROP CONSTRAINT IF EXISTS pk_trip_geom_id;
+
+DROP INDEX IF EXISTS idx_status_changes_event_time;
+DROP INDEX IF EXISTS idx_trips_start_time;
+DROP INDEX IF EXISTS idx_trips_end_time;
+DROP INDEX IF EXISTS idx_trip_geom_points;
+DROP INDEX IF EXISTS idx_status_change_geoms_event_location_geom;
+
+
+ALTER TABLE public.trips_geoms
+    ADD CONSTRAINT pk_trip_geom_id PRIMARY KEY (trip_id);
+
+CREATE INDEX idx_status_changes_event_time
+    ON public.status_changes USING btree
+    (event_time ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX idx_trips_start_time
+    ON public.trips USING btree
+    (start_time ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX idx_trips_end_time
+    ON public.trips USING btree
+    (end_time ASC NULLS LAST)
+    TABLESPACE pg_default;
+
+CREATE INDEX idx_trip_geom_points
+    ON public.trips_geoms USING gist
+    (points)
+    TABLESPACE pg_default;
+
+CREATE INDEX idx_status_change_geoms_event_location_geom
+    ON public.status_change_geoms USING gist
+    (event_location_geom)
+    TABLESPACE pg_default;

--- a/dags/transportation/dockless/indexes.sql
+++ b/dags/transportation/dockless/indexes.sql
@@ -2,38 +2,30 @@
 
 ALTER TABLE public.trips_geoms
     DROP CONSTRAINT IF EXISTS pk_trip_geom_id;
-
-DROP INDEX IF EXISTS idx_status_changes_event_time;
-DROP INDEX IF EXISTS idx_trips_start_time;
-DROP INDEX IF EXISTS idx_trips_end_time;
-DROP INDEX IF EXISTS idx_trip_geom_points;
-DROP INDEX IF EXISTS idx_status_change_geoms_event_location_geom;
-
-
 ALTER TABLE public.trips_geoms
     ADD CONSTRAINT pk_trip_geom_id PRIMARY KEY (trip_id);
 
-CREATE INDEX idx_status_changes_event_time
+CREATE INDEX IF NOT EXISTS idx_status_changes_event_time
     ON public.status_changes USING btree
     (event_time ASC NULLS LAST)
     TABLESPACE pg_default;
 
-CREATE INDEX idx_trips_start_time
+CREATE INDEX IF NOT EXISTS idx_trips_start_time
     ON public.trips USING btree
     (start_time ASC NULLS LAST)
     TABLESPACE pg_default;
 
-CREATE INDEX idx_trips_end_time
+CREATE INDEX IF NOT EXISTS idx_trips_end_time
     ON public.trips USING btree
     (end_time ASC NULLS LAST)
     TABLESPACE pg_default;
 
-CREATE INDEX idx_trip_geom_points
+CREATE INDEX IF NOT EXISTS idx_trip_geom_points
     ON public.trips_geoms USING gist
     (points)
     TABLESPACE pg_default;
 
-CREATE INDEX idx_status_change_geoms_event_location_geom
+CREATE INDEX IF NOT EXISTS idx_status_change_geoms_event_location_geom
     ON public.status_change_geoms USING gist
     (event_location_geom)
     TABLESPACE pg_default;

--- a/dags/transportation/dockless/scooter-stat.py
+++ b/dags/transportation/dockless/scooter-stat.py
@@ -6,7 +6,6 @@ import pendulum
 import sqlalchemy
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
-from airflow.operators.postgres_operator import PostgresOperator
 from airflow.operators.python_operator import PythonOperator
 from airflow.utils.email import send_email
 
@@ -33,30 +32,6 @@ default_args = {
 }
 
 dag = DAG(dag_id="scooter-stat", default_args=default_args, schedule_interval="@daily")
-
-refresh_materialized_status = """
-REFRESH MATERIALIZED VIEW v_status_changes;
-"""
-
-refresh_materialized_trips = """
-SET work_mem = '64MB';
-REFRESH MATERIALIZED VIEW v_trips;
-"""
-
-task1 = PostgresOperator(
-    task_id="update_materilized_view_status",
-    sql=refresh_materialized_status,
-    postgres_conn_id="postgres_default",
-    dag=dag,
-)
-
-
-task2 = PostgresOperator(
-    task_id="update_materilized_view_trips",
-    sql=refresh_materialized_trips,
-    postgres_conn_id="postgres_default",
-    dag=dag,
-)
 
 
 def set_xcom_variables(**kwargs):
@@ -159,6 +134,4 @@ set_xcom = PythonOperator(
     dag=dag,
 )
 
-task1.set_downstream(set_xcom)
-task2.set_downstream(set_xcom)
 email_task.set_upstream(set_xcom)

--- a/dags/transportation/dockless/scooter-stat.py
+++ b/dags/transportation/dockless/scooter-stat.py
@@ -34,7 +34,7 @@ default_args = {
 dag = DAG(dag_id="scooter-stat", default_args=default_args, schedule_interval="@daily")
 
 
-def set_xcom_variables(**kwargs):
+def compute_scooter_stats(**kwargs):
     logging.info("Connecting to DB")
     user = pg_conn.login
     password = pg_conn.get_password()
@@ -121,17 +121,17 @@ def email_callback(**kwargs):
     return True
 
 
-email_task = PythonOperator(
+send_stats_email = PythonOperator(
     task_id="scoot_stat_email",
     python_callable=email_callback,
     provide_context=True,
     dag=dag,
 )
-set_xcom = PythonOperator(
+compute_stats = PythonOperator(
     task_id="computing_stats",
     provide_context=True,
-    python_callable=set_xcom_variables,
+    python_callable=compute_scooter_stats,
     dag=dag,
 )
 
-email_task.set_upstream(set_xcom)
+compute_stats >> send_stats_email

--- a/dags/transportation/dockless/v_trips.sql
+++ b/dags/transportation/dockless/v_trips.sql
@@ -25,13 +25,14 @@ SELECT trips.provider_id,
 FROM trips INNER JOIN trips_geoms
 ON trips.trip_id = trips_geoms.trip_id
 
-ALTER VIEW public.v_trips
+ALTER TABLE public.v_trips
     OWNER TO dbadmin;
 
-GRANT SELECT ON VIEW public.v_trips TO dot_mony_ro;
-GRANT SELECT ON VIEW public.v_trips TO dot_paul_ro;
-GRANT SELECT ON VIEW public.v_trips TO dot_vlad_ro;
-GRANT ALL ON VIEW public.v_trips TO dbadmin;
+GRANT SELECT ON TABLE public.v_trips TO dot_mony_ro;
+GRANT SELECT ON TABLE public.v_trips TO dot_paul_ro;
+GRANT SELECT ON TABLE public.v_trips TO dot_romeo_ro;
+GRANT SELECT ON TABLE public.v_trips TO dot_vlad_ro;
+GRANT ALL ON TABLE public.v_trips TO dbadmin;
 
 -- view v.status_changes
 
@@ -54,10 +55,11 @@ SELECT status_changes.provider_id,
 FROM status_changes INNER JOIN status_change_geoms
 ON status_changes.id = status_change_geoms.status_change_id
 
-ALTER VIEW public.v_status_changes
+ALTER TABLE public.v_status_changes
     OWNER TO dbadmin;
 
-GRANT SELECT ON VIEW public.v_status_changes TO dot_mony_ro;
-GRANT SELECT ON VIEW public.v_status_changes TO dot_paul_ro;
-GRANT SELECT ON VIEW public.v_status_changes TO dot_vlad_ro;
-GRANT ALL ON VIEW public.v_status_changes TO dbadmin;
+GRANT SELECT ON TABLE public.v_status_changes TO dot_mony_ro;
+GRANT SELECT ON TABLE public.v_status_changes TO dot_paul_ro;
+GRANT SELECT ON TABLE public.v_status_changes TO dot_romeo_ro;
+GRANT SELECT ON TABLE public.v_status_changes TO dot_vlad_ro;
+GRANT ALL ON TABLE public.v_status_changes TO dbadmin;

--- a/dags/transportation/dockless/v_trips.sql
+++ b/dags/transportation/dockless/v_trips.sql
@@ -1,11 +1,7 @@
 -- View: public.v_trips
 
-DROP MATERIALIZED VIEW public.v_trips CASCADE;
-
-CREATE MATERIALIZED VIEW public.v_trips
-TABLESPACE pg_default
-AS
- SELECT trips.provider_id,
+CREATE OR REPLACE VIEW public.v_trips AS
+SELECT trips.provider_id,
     trips.trip_id,
     trips.provider_name,
     trips.device_id,
@@ -23,52 +19,45 @@ AS
     trips.parking_verification_url,
     trips.standard_cost,
     trips.actual_cost,
-	trips_geoms.points as trip_geometry,
-	ST_StartPoint(trips_geoms.points) as start_point,
-	ST_EndPoint(trips_geoms.points) as end_point
-   FROM trips INNER JOIN trips_geoms
-   ON
-		trips.trip_id = trips_geoms.trip_id
-WITH DATA;
+    trips_geoms.points as trip_geometry,
+    ST_StartPoint(trips_geoms.points) as start_point,
+    ST_EndPoint(trips_geoms.points) as end_point
+FROM trips INNER JOIN trips_geoms
+ON trips.trip_id = trips_geoms.trip_id
 
-ALTER TABLE public.v_trips
+ALTER VIEW public.v_trips
     OWNER TO dbadmin;
 
-GRANT SELECT ON TABLE public.v_trips TO dot_mony_ro;
-GRANT SELECT ON TABLE public.v_trips TO dot_paul_ro;
-GRANT ALL ON TABLE public.v_trips TO dbadmin;
-GRANT SELECT ON TABLE public.v_trips TO dot_vlad_ro;
+GRANT SELECT ON VIEW public.v_trips TO dot_mony_ro;
+GRANT SELECT ON VIEW public.v_trips TO dot_paul_ro;
+GRANT SELECT ON VIEW public.v_trips TO dot_vlad_ro;
+GRANT ALL ON VIEW public.v_trips TO dbadmin;
 
 -- view v.status_changes
 
-DROP MATERIALIZED VIEW public.v_status_changes CASCADE;
-
-CREATE MATERIALIZED VIEW public.v_status_changes
-TABLESPACE pg_default
-AS
- SELECT status_changes.provider_id,
+CREATE OR REPLACE VIEW public.v_status_changes AS
+SELECT status_changes.provider_id,
     status_changes.provider_name,
     status_changes.device_id,
     status_changes.vehicle_id,
-	status_changes.vehicle_type,
-	status_changes.propulsion_type,
+    status_changes.vehicle_type,
+    status_changes.propulsion_type,
     status_changes.event_type,
     status_changes.event_type_reason,
     status_changes.event_time,
-	status_changes.battery_pct,
-	status_changes.associated_trips,
-	status_changes.id,
+    status_changes.battery_pct,
+    status_changes.associated_trips,
+    status_changes.id,
     status_changes.event_location as event_location_json,
     timezone('PST'::text, status_changes.event_time) AS event_time_local,
-	status_change_geoms.event_location_geom as event_location_geom
-   FROM status_changes INNER JOIN status_change_geoms
-   ON status_changes.id = status_change_geoms.status_change_id
-WITH DATA;
+    status_change_geoms.event_location_geom as event_location_geom
+FROM status_changes INNER JOIN status_change_geoms
+ON status_changes.id = status_change_geoms.status_change_id
 
-ALTER TABLE public.v_status_changes
+ALTER VIEW public.v_status_changes
     OWNER TO dbadmin;
 
-GRANT SELECT ON TABLE public.v_status_changes TO dot_mony_ro;
-GRANT SELECT ON TABLE public.v_status_changes TO dot_paul_ro;
-GRANT ALL ON TABLE public.v_status_changes TO dbadmin;
-GRANT SELECT ON TABLE public.v_status_changes TO dot_vlad_ro;
+GRANT SELECT ON VIEW public.v_status_changes TO dot_mony_ro;
+GRANT SELECT ON VIEW public.v_status_changes TO dot_paul_ro;
+GRANT SELECT ON VIEW public.v_status_changes TO dot_vlad_ro;
+GRANT ALL ON VIEW public.v_status_changes TO dbadmin;


### PR DESCRIPTION
Fixes #135, fixes #113, follow-up to #136.

I have set some indices on the underlying `trips`, `trips_geoms`, `status_changes`, and `status_changes_geoms` tables. Once these are set, I believe that a regular view is competitive with a materialized view. If we later find this not to be the case, we can restore the materialized view for the last 30-60 days to to keep it smaller and more focused.

This should be almost entirely a drop-in replacement for the materialized view, with one caveat: in the previous materialized view `start_time_local` and `end_time_local` were indexed columns, whereas here `start_time`, and `end_time` are indexed (that is, the UTC timestamps). This is because the local versions are derived quantities from the UTC versions, and are thus not sargable unless materialized. Code that was making use of those indexes would need to be updated with some extra time zone logic.