### PR TITLE
Timezone fix

### DIFF
--- a/dags/public-health/covid19/jhu-to-esri.py
+++ b/dags/public-health/covid19/jhu-to-esri.py
@@ -49,7 +49,7 @@ jhu_time_series_featureid = "20271474d3c3404d9c79bed0dbd48580"
 jhu_current_featureid = "191df200230642099002039816dc8c59"
 
 # The date at the time of execution.
-date = pd.Timestamp.now(tz="US/Pacific").date()
+date = pd.Timestamp.now(tz="US/Pacific").normalize()
 
 # Columns expected for our county level timeseries.
 columns = [
@@ -216,7 +216,7 @@ def load_jhu_county_time_series():
         state="CA",
         travel_based=None,
         locally_acquired=None,
-        date=pd.to_datetime(df.date).dt.date,
+        date=pd.to_datetime(df.date).normalize(),
     ).drop(columns=["Country/Region"])
 
     return df.sort_values(["date", "county"]).reset_index(drop=True)
@@ -233,8 +233,9 @@ def load_esri_time_series(gis):
     sdf = sdf.drop(columns=["ObjectId", "SHAPE"]).drop_duplicates(
         subset=["date", "county"], keep="last",
     )
-    # Convert from timestamp to date for later comparisons
-    sdf = sdf.assign(date=sdf.date.dt.date)
+    # Make sure the date is a localized timestamp, otherwise ESRI assumes UTC
+    # and can show the wrong date on dashboard elements.
+    sdf = sdf.assign(date=sdf.date.dt.tz_localize("US/Pacific").dt.normalize())
     return sdf
 
 

--- a/dags/public-health/covid19/jhu-to-esri.py
+++ b/dags/public-health/covid19/jhu-to-esri.py
@@ -238,11 +238,6 @@ def load_esri_time_series(gis):
     sdf = sdf.drop(columns=["ObjectId", "SHAPE"]).drop_duplicates(
         subset=["date", "county"], keep="last",
     )
-    # Make sure the date is a localized timestamp, otherwise ESRI assumes UTC
-    # and can show the wrong date on dashboard elements.
-    sdf = sdf.assign(
-        date=sdf.date.dt.tz_localize("US/Pacific").dt.normalize().dt.tz_convert("UTC")
-    )
     return sdf
 
 


### PR DESCRIPTION
This converts the date column in the county time series from dates to datetimes in UTC. I've chosen midnight in US/Pacific in UTC as the canonical time for this timeseries.

The reason for this is that ESRI chooses UTC by default, and then converts to the dashboard user's time zone, which was causing our dates to be wrong by ~8 hours. By specifying a uniform UTC time, we get around that.

Fixes #163 