### PR TITLE
Shift historical schema back to JHU

### DIFF
--- a/dags/public-health/covid19/README.md
+++ b/dags/public-health/covid19/README.md
@@ -8,12 +8,10 @@ Contents
 
 The Johns Hopkins Center for Systems Science and Engineering has open sourced data culled from the US CDC, World Health Organization, DXY (China), China CDC (China), Hong Kong Department of Health, Macau Government, Taiwan CDC, European CDC, Government of Canada, Australia Government Department of Health, and other local, state, and regional health authorities. The team at JHU has [written a blog](https://systems.jhu.edu/research/public-health/ncov/) about their efforts in providing real-time information in the face of a global public health emergency.
 
-JHU initially published US county-level data until 3/10/2020. On 3/10, JHU started publishing only US state level data ([GitHub issue](https://github.com/CSSEGISandData/COVID-19/issues/382)). As a result, there is a major gap in JHU's county time-series data between 3/10-3/23, until they started publishing county-level data again on 3/24 ([GitHub issue](https://github.com/CSSEGISandData/COVID-19/issues/1250)). Recently, the New York Times made their [county time-series data available on GitHub](https://github.com/nytimes/covid-19-data). The NYT schema used cleaner and simpler geography naming conventions than JHU, but lacked latitude/longitude information. JHU provided hourly updates, while the NYT data was always a day behind. Through all of JHU's schema changes, the US observations were most affected, while the global observations maintained a fairly consistent schema (illustrated below).
-
-![](./data_availability.JPG)
+JHU initially published US county-level data until 3/10/2020. On 3/10, JHU started publishing only US state level data ([GitHub issue](https://github.com/CSSEGISandData/COVID-19/issues/382)). As a result, there is a major gap in JHU's county time-series data between 3/10-3/23, until they started publishing county-level data again on 3/24 ([GitHub issue](https://github.com/CSSEGISandData/COVID-19/issues/1250)). In April, JHU provided historical county time-series data going back to January in their GitHub.
 
 
-### Important JHU and NYT Source Materials
+### Important JHU and Other Source Materials
 * [JHU Dashboard](https://www.arcgis.com/apps/opsdashboard/index.html#/bda7594740fd40299423467b48e9ecf6)
 
 * [JHU ESRI feature layers for global province and country data](https://www.arcgis.com/home/item.html?id=c0b356e20b30490c8b8b4c7bb9554e7c)
@@ -24,15 +22,17 @@ JHU initially published US county-level data until 3/10/2020. On 3/10, JHU start
 
 * [JHU geography lookup table](https://github.com/CSSEGISandData/COVID-19/blob/master/csse_covid_19_data/UID_ISO_FIPS_LookUp_Table.csv)
 
-* [NYT COVID-19 GitHub repo](https://github.com/nytimes/covid-19-data)
+* [New York Times COVID-19 GitHub repo](https://github.com/nytimes/covid-19-data)
+
+* [LA Times COVID-19 GitHub repo with CA county-level data](https://github.com/datadesk/california-coronavirus-data)
 
 
 ### City of LA Workflow
 
-**4/1/2020 update:** To reconcile the mutiple schemas from JHU and NYT, we use Aqueduct, our shared pipeline for building ETLs and scheduling batch jobs. We create one table for the US and one for the rest of the world, called *global*:
+**4/9/2020 update:** We use Aqueduct, our shared pipeline for building ETLs and scheduling batch jobs. We create one table for the US and one for the rest of the world, called *global*:
 
 * **Global:** Use JHU province-level time-series data. The US is a singular observation as a country. Smaller countries report only country-level data, while larger countries like China, Australia, and Canada include province-level data.
-* **US:** Use NYT county-level time-series data up through 3/31. Then, schedule a job that pulls JHU county-level time-series data (which is updated hourly). Append those into one time-series dataset and calculate state totals.
+* **US:** Use JHU's historical county-level time-series data up through 4/8. Then, schedule a job that pulls JHU county-level time-series data (which is updated hourly). Append those into one time-series dataset and calculate state totals and change in cases from prior day.
 
 Our ETLs check JHU data ***every hour***.
 
@@ -50,17 +50,15 @@ Our ETLs check JHU data ***every hour***.
 
 * [LA County Dept of Public Health neighborhood-level current date's feature layer](http://lahub.maps.arcgis.com/home/item.html?id=999b5d0dbe2742bc92cfb126a33ff057)
 
-Soon-to-be-deprecated (created because of our 3/13 update below) -
-
-* [SCAG Region county level time-series feature layer](http://lahub.maps.arcgis.com/home/item.html?id=d61924e1d8344a09a1298707cfff388c)
-
-* [SCAG Region county level current date's feature layer](http://lahub.maps.arcgis.com/home/item.html?id=523a372d71014bd491064d74e3eba2c7)
-
 
 We believe that open source data will allow policymakers and local authorities to monitor a rapidly changing situation. It will prevent other entities from "reinventing the wheel"; we welcome collaboration and pull requests on our work!
 
 
 ### Prior Updates to Workflow
+**4/1/2020 update:** To reconcile the mutiple schemas from JHU and NYT for our US table, we use Aqueduct, our shared pipeline for building ETLs and scheduling batch jobs.
+
+* **US:** Use NYT county-level time-series data up through 3/31. Then, schedule a job that pulls JHU county-level time-series data (which is updated hourly). Append those into one time-series dataset and calculate state totals.
+
 **3/13/2020 update:** JHU's CSVs will be at the state level, and not at the city/county level anymore, [as noted in their GitHub issue](https://github.com/CSSEGISandData/COVID-19/issues/382). Since JHU's feature layers weren't connecting to our dashboard, we adapted our ETL to continue to grab province/state level data for the world and will publish these as 2 public ESRI feature layers (#1, #2). Our ETL checks JHU data ***every hour***.
 
 In addition, we are scraping the websites for Southern California counties belonging in the Southern California Association of Governments (SCAG) region. We have data from [Los Angeles](http://publichealth.lacounty.gov/media/Coronavirus/), [Orange County](http://www.ochealthinfo.com/phs/about/epidasmt/epi/dip/prevention/novel_coronavirus), and [Imperial](http://www.icphd.org/health-information-and-resources/healthy-facts/covid-19/) Counties. In the coming days, we will add [Ventura](https://www.ventura.org/covid19/), [Riverside](https://www.rivcoph.org/coronavirus), and [San Bernardino](http://wp.sbcounty.gov/dph/coronavirus/) Counties. We have combined JHU county data up to 3/12/2020 with our own compilation of counts, and will publish these as 2 public ESRI feature layers (#3, #4). Our ETL scrapes case counts published by county public health agency websites ***every hour***.

--- a/dags/public-health/covid19/create-us-county-time-series.py
+++ b/dags/public-health/covid19/create-us-county-time-series.py
@@ -230,7 +230,7 @@ def calculate_change(df):
 
     for col in ["cases", "deaths"]:
         new_col = f"new_{col}"
-        county_group_cols = ["state", "county"]
+        county_group_cols = ["state", "county", "fips"]
         df[new_col] = (
             df.sort_values(group_cols)
             .groupby(county_group_cols)[col]

--- a/dags/public-health/covid19/create-us-county-time-series.py
+++ b/dags/public-health/covid19/create-us-county-time-series.py
@@ -61,7 +61,7 @@ def correct_county_fips(row):
 # (1) Bring in JHU historical county time-series data and clean
 bucket_name = "public-health-dashboard"
 
-JHU_COMMIT = "1a68338bddea934490f772051121adad47bf543e"
+JHU_COMMIT = "5acaa8f852178af7f0c9eebfd0d5db746bbb2305"
 
 CASES_URL = (
     f"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/{JHU_COMMIT}/"
@@ -153,6 +153,10 @@ def clean_jhu_county(df):
         },
         inplace=True,
     )
+
+    # Use floats
+    for col in ["people_tested", "incident_rate"]:
+        df[col] = df[col].astype(float)
 
     # Fix fips
     df = df.pipe(coerce_fips_integer)
@@ -325,6 +329,4 @@ us_county = calculate_change(us_county)
 final = fix_column_dtypes(us_county)
 
 # Export as csv
-final.to_csv(
-    f"s3://{bucket_name}/jhu_covid19/county_time_series_331_TEST.csv", index=False
-)
+final.to_csv(f"s3://{bucket_name}/jhu_covid19/county_time_series_408.csv", index=False)

--- a/dags/public-health/covid19/create-us-county-time-series.py
+++ b/dags/public-health/covid19/create-us-county-time-series.py
@@ -1,13 +1,55 @@
 """
-Run this once to set the schema for US county-level data
-This grabs NYT data up to 3/31 and sample JHU data for 3/30 to append
+Set the schema for US county-level data
+using only JHU data.
+Grab historical time-series data from JHU GitHub
+and append 4/8 JHU feature layer.
 """
 import geopandas as gpd
 import numpy as np
 import pandas as pd
 
+bucket_name = "public-health-dashboard"
 
-# Functions to be used
+JHU_HISTORICAL_COMMIT = "1a68338bddea934490f772051121adad47bf543e"
+
+CASES_URL = (
+    f"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/{JHU_HISTORICAL_COMMIT}/"
+    "csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_confirmed_US.csv"
+)
+
+DEATHS_URL = (
+    f"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/{JHU_HISTORICAL_COMMIT}/"
+    "csse_covid_19_data/csse_covid_19_time_series/time_series_covid19_deaths_US.csv"
+)
+
+# General functions to be used
+def parse_columns(df):
+    """
+    quick helper function to parse columns into values
+    uses for pd.melt
+    """
+    columns = list(df.columns)
+
+    id_vars, dates = [], []
+
+    for c in columns:
+        if c.endswith("20"):
+            dates.append(c)
+        else:
+            id_vars.append(c)
+    return id_vars, dates
+
+
+def rename_geog_cols(df):
+    """
+    # Rename geography columns to be the same as future schemas
+    """
+    df.rename(
+        columns={"Long_": "Lon", "FIPS": "fips"}, inplace=True,
+    )
+    return df
+
+
 def coerce_fips_integer(df):
     def integrify(x):
         return int(float(x)) if not pd.isna(x) else None
@@ -30,51 +72,61 @@ def correct_county_fips(row):
         return ""
 
 
-# (1) Bring in NYT US county level data and clean
-NYT_COMMIT = "baeca648aefa9694a3fc8f2b3bd3f797937aa1c5"
-NYT_COUNTY_URL = (
-    f"https://raw.githubusercontent.com/nytimes/covid-19-data/{NYT_COMMIT}/"
-    "us-counties.csv"
-)
-county = pd.read_csv(NYT_COUNTY_URL)
+# (1) Bring in JHU historical county time-series data and clean
+def load_jhu_us_time_series():
 
+    cases = pd.read_csv(CASES_URL)
+    deaths = pd.read_csv(DEATHS_URL)
 
-def clean_nyt_county(df):
-    keep_cols = ["date", "county", "state", "fips", "cases", "deaths"]
-    df = df[keep_cols]
-    df["date"] = pd.to_datetime(df.date)
-    # Create new columns to store what JHU reports
-    df["incident_rate"] = np.nan
-    df["people_tested"] = np.nan
-    # Fix column type
-    df = coerce_fips_integer(df)
+    # melt cases
+    id_vars, dates = parse_columns(cases)
+    df = pd.melt(
+        cases, id_vars=id_vars, value_vars=dates, value_name="cases", var_name="date",
+    )
+
+    # melt deaths
+    id_vars, dates = parse_columns(deaths)
+    deaths_df = pd.melt(deaths, id_vars=id_vars, value_vars=dates, value_name="deaths")
+
+    # join
+    df = (
+        df.assign(deaths=deaths_df.deaths, state=df.Province_State, county=df.Admin2,)
+        .pipe(rename_geog_cols)
+        .pipe(coerce_fips_integer)
+    )
+
+    # Fix fips and make it a 5 digit string
     df["fips"] = df.fips.astype(str)
     df["fips"] = df.apply(correct_county_fips, axis=1)
-    return df
+
+    drop_col = [
+        "UID",
+        "iso2",
+        "iso3",
+        "code3",
+        "Province_State",
+        "Country_Region",
+        "Admin2",
+    ]
+
+    df = df.drop(columns=drop_col)
+
+    for col in ["state", "county", "fips"]:
+        df[col] = df[col].fillna("")
+
+    # Make sure date is UTC
+    df["date"] = pd.to_datetime(df.date)
+    df = df.assign(date=df.date.dt.tz_localize("UTC"))
+
+    return df.sort_values(["state", "county", "date"]).reset_index(drop=True)
 
 
-county = clean_nyt_county(county)
-
-
-# (2) Add JHU data for 3/30 and clean up geography
-bucket_name = "public-health-dashboard"
-jhu = gpd.read_file(
-    f"s3://{bucket_name}/jhu_covid19/jhu_feature_layer_3_30_2020.geojson"
-)
-jhu["date"] = "3/30/2020"
-jhu["date"] = pd.to_datetime(jhu.date)
-
-
-# Bring in the NYT's way of naming geographies, use FIPS to merge
-nyt_geog = county[county.fips != ""][["fips", "county", "state"]].drop_duplicates()
-
-
-# Clean JHU data to match NYT schema
+# (2) Bring in current JHU feature layer and clean
 def clean_jhu_county(df):
     # Only keep certain columns and rename them to match NYT schema
     keep_cols = [
         "Province_State",
-        "Country_Region",
+        "Admin2",
         "Lat",
         "Long_",
         "Confirmed",
@@ -83,51 +135,39 @@ def clean_jhu_county(df):
         "Incident_Rate",
         "People_Tested",
         "date",
+        "Combined_Key",
     ]
 
     df = df[keep_cols]
 
     df.rename(
         columns={
-            "Confirmed": "cases",
             "Deaths": "deaths",
             "FIPS": "fips",
             "Long_": "Lon",
+            "Province_State": "state",
+            "Admin2": "county",
             "People_Tested": "people_tested",
             "Incident_Rate": "incident_rate",
         },
         inplace=True,
     )
 
-    # Use FIPS to merge in NYT columns for county and state names
-    # There are some values with no FIPS, NYT calls these county = "Unknown"
-    df = pd.merge(df, nyt_geog, on="fips", how="left", validate="m:1")
+    df = df.pipe(coerce_fips_integer)
 
-    # Fix when FIPS is unknown, which wouldn't have merged in anything from nyt_geog
-    df["county"] = df.apply(
-        lambda row: "Unknown" if row.fips is None else row.county, axis=1
-    )
-    df["state"] = df.apply(
-        lambda row: row.Province_State if row.fips is None else row.state, axis=1
-    )
-    df["fips"] = df.fips.fillna("")
-
-    # Only keep certain columns and rename them to match NYT schema
-    drop_cols = ["Province_State", "Country_Region"]
-
-    df = df.drop(columns=drop_cols)
+    for col in ["state", "county", "fips"]:
+        df[col] = df[col].fillna("")
 
     return df
 
 
-jhu = clean_jhu_county(jhu)
-
-
-# (3) Append NYT and JHU and fill in missing county lat/lon
-us_county = county.append(jhu, sort=False)
-
-
+# (3) Fill in missing stuff after appending
 def fill_missing_stuff(df):
+    # Standardize how New York City shows up
+    df["county"] = df.apply(
+        lambda row: "New York City" if row.fips == "36061" else row.county, axis=1
+    )
+
     not_missing_coords = df[df.Lat.notna()][
         ["state", "county", "Lat", "Lon"]
     ].drop_duplicates()
@@ -149,77 +189,28 @@ def fill_missing_stuff(df):
     return df
 
 
-us_county = fill_missing_stuff(us_county)
-
-
-# (4) Import crosswalk from JHU to fix missing state lat/lon
-JHU_COMMIT = "376119aa4b3dbc37b863ac11d4984e480e81227b"
-JHU_LOOKUP_URL = (
-    f"https://raw.githubusercontent.com/CSSEGISandData/COVID-19/{JHU_COMMIT}/"
-    "csse_covid_19_data/UID_ISO_FIPS_LookUp_Table.csv"
-)
-
-# Fix values with missing lat/lon (NYT breaks out Kansas City, MO and NYC, NY)
-jhu_lookup = pd.read_csv(JHU_LOOKUP_URL)
-cols_to_keep = ["Province_State", "Lat", "Long_"]
-jhu_lookup = jhu_lookup[jhu_lookup.Country_Region == "US"][cols_to_keep]
-jhu_lookup.rename(columns={"Province_State": "state", "Long_": "Lon"}, inplace=True)
-
-# Fix the different types of missing lat/lon
-cond1 = "us_county.Lat.isna()"
-cond2 = "us_county.county.notna()"
-fix_county = us_county[(cond1) and (cond2) and (us_county.county != "Unknown")]
-fix_state = us_county[(cond1) and (cond2) and (us_county.county == "Unknown")]
-rest_of_df = us_county[us_county.Lat.notna()]
-
-fix_county_lat = {
-    "Kansas City": 39.0997,
-    "New York City": 40.7128,
-}
-fix_county_lon = {
-    "Kansas City": -94.5786,
-    "New York City": -74.0060,
-}
-fix_county["Lat"] = fix_county.county.map(fix_county_lat)
-fix_county["Lon"] = fix_county.county.map(fix_county_lon)
-
-fix_state = pd.merge(
-    fix_state.drop(columns=["Lat", "Lon"]), jhu_lookup, on="state", how="left"
-)
-
-
-# Append the fixes together
-us_county = (
-    rest_of_df.append(fix_county, sort=False).append(fix_state).reset_index(drop=True)
-)
-us_county = us_county.sort_values(
-    ["fips", "state", "county", "date", "cases", "Lat", "Lon"],
-    ascending=[True, True, True, True, True, True, True],
-).drop_duplicates(subset=["fips", "state", "county", "date"], keep="first")
-
-
-# (5) Calculate US State totals
+# (4) Calculate US state totals
 def us_state_totals(df):
-
     state_grouping_cols = ["state", "date"]
 
     state_totals = df.groupby(state_grouping_cols).agg(
         {"cases": "sum", "deaths": "sum"}
     )
-
-    state_totals.rename(
-        columns={"cases": "state_cases", "deaths": "state_deaths"}, inplace=True
+    state_totals = state_totals.rename(
+        columns={"cases": "state_cases", "deaths": "state_deaths"}
     )
 
-    df = pd.merge(df, state_totals, on=state_grouping_cols)
+    df = pd.merge(
+        # df.drop(columns=["state_cases", "state_deaths"]),
+        df,
+        state_totals,
+        on=state_grouping_cols,
+    )
 
     return df
 
 
-us_county = us_state_totals(us_county)
-
-
-# (6) Calculate change in casesload from the prior day
+# (5) Calculate change in caseloads from prior day
 def calculate_change(df):
     group_cols = ["state", "county", "fips", "date"]
 
@@ -247,19 +238,8 @@ def calculate_change(df):
     return df
 
 
-us_county = calculate_change(us_county)
-
-
-# (7) Fix column types before exporting
+# (6) Fix column types before exporting
 def fix_column_dtypes(df):
-    df["date"] = (
-        pd.to_datetime(df.date)
-        .dt.tz_localize("US/Pacific")
-        .dt.normalize()
-        .dt.tz_convert("UTC")
-    )
-
-    # integrify wouldn't work?
     def coerce_integer(df):
         def integrify(x):
             return int(float(x)) if not pd.isna(x) else None
@@ -305,14 +285,41 @@ def fix_column_dtypes(df):
         .sort_values(["state", "county", "fips", "date", "cases"])
     )
 
+    print(df.dtypes)
+
     return df
 
 
-us_county = fix_column_dtypes(us_county)
+# Create our time-series file
+cases = pd.read_csv(CASES_URL)
+deaths = pd.read_csv(DEATHS_URL)
 
-print(us_county.dtypes)
+# (1) Bring in JHU historical county time-series data and clean
+df = load_jhu_us_time_series()
+
+# (2) Bring in current JHU feature layer and clean
+jhu = gpd.read_file(
+    f"s3://{bucket_name}/jhu_covid19/jhu_feature_layer_4_8_2020.geojson"
+)
+jhu["date"] = "4/8/2020"
+jhu["date"] = pd.to_datetime(jhu.date).dt.tz_localize("UTC")
+
+jhu = clean_jhu_county(jhu)
+
+# Append datasets
+ts = df.append(jhu, sort=False)
+
+# (3) Fill in missing stuff after appending
+us_county = fill_missing_stuff(ts)
+
+# (4) Calculate US state totals
+us_county = us_state_totals(us_county)
+
+# (5) Calculate change in caseloads from prior day
+us_county = calculate_change(us_county)
+
+# (6) Fix column types before exporting
+final = fix_column_dtypes(us_county)
 
 # Export as csv
-us_county.to_csv(
-    f"s3://{bucket_name}/jhu_covid19/county_time_series_331.csv", index=False
-)
+final.to_csv(f"s3://{bucket_name}/jhu_covid19/county_time_series_331.csv", index=False)

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -119,6 +119,10 @@ def clean_jhu_county(df):
         inplace=True,
     )
 
+    # Use floats
+    for col in ["people_tested", "incident_rate"]:
+        df[col] = df[col].astype(float)
+
     # Fix fips
     df = df.pipe(coerce_fips_integer)
     df["fips"] = df.fips.astype(str)

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -4,9 +4,8 @@ and add JHU DAG to this.
 """
 from datetime import datetime, timedelta
 
-import pandas as pd
-
 import arcgis
+import pandas as pd
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
@@ -86,7 +85,9 @@ def correct_county_fips(row):
     else:
         return row.fips
 
+
 sort_cols = ["state", "county", "fips", "date"]
+
 
 # (2) Bring in current JHU feature layer and clean
 def clean_jhu_county(df):
@@ -158,10 +159,10 @@ def fill_missing_stuff(df):
 
     df = (
         df.drop_duplicates(subset=sort_cols, keep="last")
-            .sort_values(sort_cols)
-            .reset_index(drop=True)
+        .sort_values(sort_cols)
+        .reset_index(drop=True)
     )
-    
+
     return df
 
 
@@ -175,9 +176,9 @@ def us_state_totals(df):
     state_totals = state_totals.rename(
         columns={"cases": "state_cases", "deaths": "state_deaths"}
     )
-        
+
     df = pd.merge(
-        df,
+        df.drop(columns=["state_cases", "state_deaths"]),
         state_totals,
         on=state_grouping_cols,
     )
@@ -207,7 +208,7 @@ def calculate_change(df):
             .apply(lambda row: row - row.shift(1))
         )
         df[new_col] = df[new_col].fillna(df[col])
-   
+
     return df
 
 

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -188,7 +188,7 @@ def calculate_change(df):
 
     for col in ["cases", "deaths"]:
         new_col = f"new_{col}"
-        county_group_cols = ["state", "county"]
+        county_group_cols = ["state", "county", "fips"]
         df[new_col] = (
             df.sort_values(group_cols)
             .groupby(county_group_cols)[col]


### PR DESCRIPTION
* NYC wasn't properly captured and retained in current JHU feature layer
* Since JHU GitHub now has historical time-series for county data, let's swap out NYT. Reduce the need to fill in columns by "borrowing" from the other dataset and vice versa.
* Maintain the simpler, cleaner schema still, no need to change feature ID