### PR TITLE
Fix file system race condition.

### DIFF
--- a/dags/public-health/covid19/get_help_to_esri.py
+++ b/dags/public-health/covid19/get_help_to_esri.py
@@ -189,9 +189,9 @@ def assemble_get_help_timeseries():
 
 def load_get_help_data(**kwargs):
     facilities = get_facilities()
-    upload_to_esri(facilities, FACILITIES_ID, "/tmp/facilities.csv")
+    upload_to_esri(facilities, FACILITIES_ID, "/tmp/gethelp-facilities.csv")
     timeseries = assemble_get_help_timeseries()
-    upload_to_esri(timeseries, TIMESERIES_ID, "/tmp/timeseries.csv")
+    upload_to_esri(timeseries, TIMESERIES_ID, "/tmp/gethelp-timeseries.csv")
 
     # Compute a number of open and reporting shelter beds
     active_facilities = facilities[facilities.status != 0]
@@ -209,7 +209,7 @@ def load_get_help_data(**kwargs):
         stats, orient="index", columns=["Count"]
     ).transpose()
     # TODO: Write an assert to make sure all rows are in resultant GDF
-    upload_to_esri(stats_df, STATS_ID, "/tmp/stats.csv")
+    upload_to_esri(stats_df, STATS_ID, "/tmp/gethelp-stats.csv")
 
 
 default_args = {

--- a/dags/public-health/covid19/shelter-to-esri.py
+++ b/dags/public-health/covid19/shelter-to-esri.py
@@ -106,7 +106,7 @@ def load_data(**kwargs):
     # export to CSV
     gdf["Latitude"] = gdf.geometry.y
     gdf["Longitude"] = gdf.geometry.x
-    time_series_filename = "/tmp/shelter-timeseries-v3.csv"
+    time_series_filename = "/tmp/rap-shelter-timeseries-v3.csv"
 
     df = pd.DataFrame(gdf).drop(
         ["geometry", "date", "time", "reported_datetime"], axis=1
@@ -126,7 +126,7 @@ def load_data(**kwargs):
         + latest_df["Total Men Currently at Site"]
     )
 
-    latest_filename = "/tmp/latest-shelters-v3.csv"
+    latest_filename = "/tmp/rap-latest-shelters-v3.csv"
     latest_df.to_csv(latest_filename, index=False)
 
     # Compute a number of open and reporting shelter beds
@@ -146,7 +146,7 @@ def load_data(**kwargs):
 
     upload_to_esri(latest_df, LATEST_ID, filename=latest_filename)
     upload_to_esri(df, SHELTER_ID, filename=time_series_filename)
-    upload_to_esri(stats_df, STATS_ID, filename="/tmp/stats.csv")
+    upload_to_esri(stats_df, STATS_ID, filename="/tmp/rap-shelter-stats.csv")
     return True
 
 


### PR DESCRIPTION
Collision in file names causes occasional failures at the top of the hour when the shelter and gethelp DAGs run.

A more permanent fix would be to use the python `tempfile` functionality, which I think we should do in `esri-utils`.