### PR TITLE
COVID 19 Testing DAG

### DIFF
--- a/dags/public-health/covid19/README.md
+++ b/dags/public-health/covid19/README.md
@@ -115,6 +115,14 @@ Specifically, it produces:
 * [Current shelters](http://lahub.maps.arcgis.com/home/item.html?id=51a351e257374ed3a7776612c7eb0c6a) - A snapshot of the current status of bed counts for the shelters. Some shelters may be listed that are not yet active, and have inaccurate information. You can remove them by filtering for `status != 0`.
 * [Shelter stats](http://lahub.maps.arcgis.com/home/item.html?id=9db2e26c98134fae9a6f5c154a1e9ac9) - Some aggregate statistics of the current shelter status, including number of unique shelters, number with known status, and number of available beds.
 
+## Testing Data
+
+The City collects data on the number of tests performed and test kits available from its several COVID-19 testing sites. The DAG `sync_covid_testing_data.py` collects the data from a [Google sheet](https://docs.google.com/spreadsheets/d/1agPpAJ5VNqpY50u9RhcPOu7P54AS0NUZhvA2Elmp2m4/edit?usp=sharing), and uploads it to the [LA COVID Testing V5 Layer](http://lahub.maps.arcgis.com/home/item.html?id=f00ffb81e4b848b192bc993cd22e0acf) on ESRI for dashboarding and analysis.
+
+## Hospital Bed and Equipment Availability
+
+The County issues a [daily pdf survey](http://file.lacounty.gov/SDSInter/dhs/1070069_HavBedSummary.pdf) on the number of beds and ventilators that are available, unavailable, or occupied by COVID-19 patients. This survey is manually entered into a [Google sheet](https://docs.google.com/spreadsheets/d/1rS0Vt-kuxwQKoqZBcaOYOOTc5bL1QZqAqqPSyCaMczQ/edit?usp=sharing), and uploaded to the [Bed Availability V4 Layer](http://lahub.maps.arcgis.com/home/item.html?id=956e105f422a4c1ba9ce5d215b835951) on ESRI for dashboarding and analysis.
+
 ## Contributors
 * [Hunter Owens](https://github.com/hunterowens)
 * [Ian Rose](https://github.com/ian-r-rose)

--- a/dags/public-health/covid19/sync_covid_testing_data.py
+++ b/dags/public-health/covid19/sync_covid_testing_data.py
@@ -52,7 +52,7 @@ default_args = {
     "retry_delay": datetime.timedelta(days=1),
 }
 
-cron_string = "0 11-23 * * *"
+cron_string = "0 0-6,18-23 * * *"
 
 dag = DAG(
     "covid-testing-data", default_args=default_args, schedule_interval=cron_string

--- a/dags/public-health/covid19/sync_covid_testing_data.py
+++ b/dags/public-health/covid19/sync_covid_testing_data.py
@@ -53,7 +53,11 @@ default_args = {
     "retry_delay": datetime.timedelta(days=1),
 }
 
-dag = DAG("covid-testing-data", default_args=default_args, schedule_interval="@hourly")
+cron_string = "0 11-23 * * *"
+
+dag = DAG(
+    "covid-testing-data", default_args=default_args, schedule_interval=cron_string
+)
 
 
 def update_covid_testing_data(**kwargs):

--- a/dags/public-health/covid19/sync_covid_testing_data.py
+++ b/dags/public-health/covid19/sync_covid_testing_data.py
@@ -5,7 +5,6 @@ import datetime
 
 import arcgis
 import pandas as pd
-
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
@@ -40,7 +39,7 @@ def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime.datetime(2020, 4, 16),
+    "start_date": datetime.datetime(2020, 4, 22),
     "email": [
         "ian.rose@lacity.org",
         "hunter.owens@lacity.org",

--- a/dags/public-health/covid19/sync_covid_testing_data.py
+++ b/dags/public-health/covid19/sync_covid_testing_data.py
@@ -53,7 +53,7 @@ default_args = {
     "retry_delay": datetime.timedelta(days=1),
 }
 
-dag = DAG("covid-testing-data", default_args=default_args, schedule_interval="@daily")
+dag = DAG("covid-testing-data", default_args=default_args, schedule_interval="@hourly")
 
 
 def update_covid_testing_data(**kwargs):

--- a/dags/public-health/covid19/sync_covid_testing_data.py
+++ b/dags/public-health/covid19/sync_covid_testing_data.py
@@ -1,0 +1,95 @@
+"""
+Pull data from MOPS COVID Dashboard and upload to ESRI
+"""
+import datetime
+import os
+
+import arcgis
+import pandas as pd
+
+from airflow import DAG
+from airflow.hooks.base_hook import BaseHook
+from airflow.hooks.S3_hook import S3Hook
+from airflow.operators.python_operator import PythonOperator
+
+
+def get_data(filename, workbook, sheet_name):
+    df = pd.read_excel(workbook, sheet_name=sheet_name, skiprows=1, index_col=0)
+    df = df.T
+    df = df.iloc[:, 1:3]
+    df.reset_index(level=0, inplace=True)
+    df.columns = ["Date", "Performed", "Test Kit Inventory"]
+    df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
+    df = df.loc[df["Date"].dt.date < datetime.datetime.now().date()]
+    df.to_csv(filename, index=False)
+
+
+def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):
+    filename = "/tmp/%s" % filename
+    gis = arcgis.GIS("http://lahub.maps.arcgis.com", arcuser, arcpassword)
+    gis_item = gis.content.get(arcfeatureid)
+    gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
+    gis_layer_collection.manager.overwrite(filename)
+
+
+def upload_to_s3(filename, bucket):
+    path = "/tmp/%s" % filename
+    s3 = S3Hook("s3_conn")
+    s3.load_file(path, filename, bucket, replace=True)
+
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": datetime.datetime(2020, 4, 16),
+    "email": [
+        "ian.rose@lacity.org",
+        "hunter.owens@lacity.org",
+        "brendan.bailey@lacity.org",
+    ],
+    "email_on_failure": True,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": datetime.timedelta(days=1),
+}
+
+dag = DAG("covid-testing-data", default_args=default_args, schedule_interval="@daily")
+
+
+def update_covid_testing_data(**kwargs):
+    """
+    The actual python callable that Airflow schedules.
+    """
+    # Getting data from google sheet
+    filename = kwargs.get("filename")
+    workbook = kwargs.get("workbook")
+    sheet_name = kwargs.get("sheet_name")
+    get_data(filename, workbook, sheet_name)
+
+    # Updating ArcGis
+    arcconnection = BaseHook.get_connection("arcgis")
+    arcuser = arcconnection.login
+    arcpassword = arcconnection.password
+    arcfeatureid = kwargs.get("arcfeatureid")
+    update_arcgis(arcuser, arcpassword, arcfeatureid, filename)
+
+    # Upload to s3
+    upload_to_s3(filename, "jhu_covid19")
+    os.remove("/tmp/%s" % filename)
+
+
+# Sync ServiceRequestData.csv
+t1 = PythonOperator(
+    task_id="update_COVID_Testing_Data",
+    provide_context=True,
+    python_callable=update_covid_testing_data,
+    op_kwargs={
+        "filename": "COVID_testing_data.csv",
+        "arcfeatureid": "f00ffb81e4b848b192bc993cd22e0acf",
+        "workbook": "https://docs.google.com/spreadsheets/d/"
+        "1agPpAJ5VNqpY50u9RhcPOu7P54AS0NUZhvA2Elmp2m4/"
+        "export?format=xlsx&#gid=0",
+        "sheet_name": "DUPLICATE OF MOPS",
+    },
+    dag=dag,
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ s3fs==0.4.0
 seaborn==0.9.0
 sodapy==2.0.0
 tableauserverclient==0.9
-xlrd=1.1
+xlrd==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ s3fs==0.4.0
 seaborn==0.9.0
 sodapy==2.0.0
 tableauserverclient==0.9
+xlrd=1.1


### PR DESCRIPTION
This is the first draft of the dag that pulls testing data from the MOPS dashboard, and syncs it with AGOL. It's essentially a copy of the RAP data dag

One question I was wondering if it's possible/easy to have the dag run hourly after a given set time of day?

The MOPS team is supposed to update it before COB everyday, but there is a chance they may not update until the following morning. I think having the DAG run everyday after 11am would make sense. Hourly would be good in case they make changes to the google sheet throughout the day