### PR TITLE
Update maxRecordCount

### DIFF
--- a/dags/public-health/covid19/get-help-to-esri.py
+++ b/dags/public-health/covid19/get-help-to-esri.py
@@ -2,10 +2,9 @@ import datetime
 import os
 from urllib.parse import urljoin
 
+import arcgis
 import pandas
 import requests
-
-import arcgis
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Variable

--- a/dags/public-health/covid19/get-help-to-esri.py
+++ b/dags/public-health/covid19/get-help-to-esri.py
@@ -2,9 +2,10 @@ import datetime
 import os
 from urllib.parse import urljoin
 
-import arcgis
 import pandas
 import requests
+
+import arcgis
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.models import Variable

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -17,7 +17,7 @@ from arcgis.gis import GIS
 TIME_SERIES_FEATURE_ID = "4e0dc873bd794c14b7bd186b4b5e74a2"
 JHU_FEATURE_ID = "628578697fb24d8ea4c32fa0c5ae1843"
 MSA_FEATURE_ID = "b37e229b71dc4c65a479e4b5912ded66"
-max_record_count = 2_000_000
+max_record_count = 6_000_000
 
 
 def append_county_time_series(**kwargs):

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -5,9 +5,8 @@ and add JHU DAG to this.
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd
-
 import arcgis
+import pandas as pd
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -5,8 +5,9 @@ and add JHU DAG to this.
 import os
 from datetime import datetime, timedelta
 
-import arcgis
 import pandas as pd
+
+import arcgis
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
@@ -16,6 +17,7 @@ from arcgis.gis import GIS
 TIME_SERIES_FEATURE_ID = "4e0dc873bd794c14b7bd186b4b5e74a2"
 JHU_FEATURE_ID = "628578697fb24d8ea4c32fa0c5ae1843"
 MSA_FEATURE_ID = "b37e229b71dc4c65a479e4b5912ded66"
+max_record_count = 2_000_000
 
 
 def append_county_time_series(**kwargs):
@@ -63,6 +65,7 @@ def append_county_time_series(**kwargs):
     gis_item = gis.content.get(TIME_SERIES_FEATURE_ID)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
     gis_layer_collection.manager.overwrite(time_series_filename)
+    gis_layer_collection.manager.update_definition({"maxRecordCount": max_record_count})
 
     return True
 
@@ -359,6 +362,7 @@ def update_msa_dataset(**kwargs):
     gis_item = gis.content.get(MSA_FEATURE_ID)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
     gis_layer_collection.manager.overwrite(MSA_FILENAME)
+    gis_layer_collection.manager.update_definition({"maxRecordCount": max_record_count})
 
     os.remove(MSA_FILENAME)
     return

--- a/dags/public-health/covid19/jhu-to-esri.py
+++ b/dags/public-health/covid19/jhu-to-esri.py
@@ -6,8 +6,9 @@ import logging
 import os
 from datetime import datetime, timedelta
 
-import arcgis
 import pandas as pd
+
+import arcgis
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
@@ -46,6 +47,8 @@ current_featureid = "523a372d71014bd491064d74e3eba2c7"
 # Feature IDs for state/province level time series and current status
 jhu_time_series_featureid = "20271474d3c3404d9c79bed0dbd48580"
 jhu_current_featureid = "191df200230642099002039816dc8c59"
+
+max_record_count = 6_000_000
 
 # The date at the time of execution. We choose midnight in the US/Pacific timezone,
 # but then convert to UTC since that is what AGOL expects. When the feature layer
@@ -208,10 +211,12 @@ def load_global_covid_data():
     gis_item = gis.content.get(jhu_time_series_featureid)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
     gis_layer_collection.manager.overwrite(time_series_filename)
+    gis_layer_collection.manager.update_definition({"maxRecordCount": max_record_count})
 
     gis_item = gis.content.get(jhu_current_featureid)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
     gis_layer_collection.manager.overwrite(most_recent_date_filename)
+    gis_layer_collection.manager.update_definition({"maxRecordCount": max_record_count})
 
     # Clean up
     os.remove(time_series_filename)

--- a/dags/public-health/covid19/jhu-to-esri.py
+++ b/dags/public-health/covid19/jhu-to-esri.py
@@ -6,9 +6,8 @@ import logging
 import os
 from datetime import datetime, timedelta
 
-import pandas as pd
-
 import arcgis
+import pandas as pd
 from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator


### PR DESCRIPTION
Update the definition so maxRecordCount isn't the default of 2000, but much larger. When querying, only 2000 rows will show in Jupyter Notebook, but our dataset is much bigger.

We will use 6M as the maxRecordCount, and apply it to `us_county_time_series`, `MSA_Comps_COVID`, `jhu_covid19_time_series`, and `jhu_covid19_current`

Ref GH issue: #203 