### PR TITLE
disable isort.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,10 +9,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
-    hooks:
-      - id: isort
   - repo: https://github.com/psf/black
     rev: 19.10b0
     hooks:


### PR DESCRIPTION
The results are in, and apparently nobody can get this installed so that it is the same version as in CI.