### PR TITLE
Quick fix for client events.

### DIFF
--- a/dags/public-health/covid19/get-help-to-esri.py
+++ b/dags/public-health/covid19/get-help-to-esri.py
@@ -149,7 +149,11 @@ def get_client_stats(facility_id):
     res = make_get_help_request(
         f"facilities/{facility_id}/client-statistics", TOKEN, paginated=False,
     )
-    return pandas.Series({**res, **res["genderStats"]}).drop("genderStats").astype(int)
+    return (
+        pandas.Series({**res, **res["genderStats"]})
+        .drop(["genderStats", "clientEvents"])
+        .astype(int)
+    )
 
 
 def get_program_client_stats(facility_id, program_id):
@@ -176,7 +180,11 @@ def get_program_client_stats(facility_id, program_id):
         TOKEN,
         paginated=False,
     )
-    return pandas.Series({**res, **res["genderStats"]}).drop("genderStats").astype(int)
+    return (
+        pandas.Series({**res, **res["genderStats"]})
+        .drop(["genderStats", "clientEvents"])
+        .astype(int)
+    )
 
 
 def agg_facility_programs(facility_id, program_list, match, prefix):


### PR DESCRIPTION
GetHelp just pushed some changes to their API that we need to respond to. We will have to do more work to incorporate EMS calls, but for now this should fix the broken DAG runs.