### PR TITLE
Correcting string issue for LA Cases Table

### DIFF
--- a/dags/public-health/covid19/README.md
+++ b/dags/public-health/covid19/README.md
@@ -26,7 +26,7 @@ We've documented all the data that feeds into the City of LA COVID-19 Dashboard 
 
 * [LA County Dept of Public Health neighborhood-level current date's feature layer](http://lahub.maps.arcgis.com/home/item.html?id=80627302612e49ef8145eac24c61e196)
 
-* [City of LA case count time-series table](https://lahub.maps.arcgis.com/home/item.html?id=412c839a52044aa5a5b115552346e8b5)
+* [City of LA case count time-series table](https://lahub.maps.arcgis.com/home/item.html?id=1d1e4679a94e43e884b97a0488fc04cf)
 
 * The relevant scripts are: `jhu-to-esri.py`, `jhu-county-to-esri.py`, and `sync-la-cases-data.py`.
 

--- a/dags/public-health/covid19/sync-la-cases-data.py
+++ b/dags/public-health/covid19/sync-la-cases-data.py
@@ -11,6 +11,12 @@ from airflow.operators.python_operator import PythonOperator
 
 def get_data(filename, workbook, sheet_name):
     df = pd.read_excel(workbook, sheet_name=sheet_name)
+    df = df.loc[:, ["Date", "City of LA Cases", "City of LA New Cases"]]
+    df.dropna(
+        subset=["City of LA Cases", "City of LA New Cases"], how="all", inplace=True
+    )
+    df["City of LA Cases"] = df["City of LA Cases"].astype(int)
+    df["City of LA New Cases"] = df["City of LA New Cases"].astype(int)
     df.to_csv(filename, index=False)
 
 
@@ -64,8 +70,8 @@ t1 = PythonOperator(
     provide_context=True,
     python_callable=update_la_cases_data,
     op_kwargs={
-        "filename": "/tmp/LA_Cases_Table.csv",
-        "arcfeatureid": "412c839a52044aa5a5b115552346e8b5",
+        "filename": "/tmp/LA_Cases_Table_V2.csv",
+        "arcfeatureid": "1d1e4679a94e43e884b97a0488fc04cf",
         "workbook": "https://docs.google.com/spreadsheets/d/"
         "1Vk7aGL7O0ZVQRySwh6X2aKlbhYlAR_ppSyMdMPqz_aI/"
         "export?format=xlsx&#gid=0",


### PR DESCRIPTION
This is correcting the issue that Rene brought up. With converting the data types from floats to ints, the data should be represented in AGOL as ints rather than strings.