### PR TITLE
Correcting covid testing dag timezone issue

### DIFF
--- a/dags/public-health/covid19/README.md
+++ b/dags/public-health/covid19/README.md
@@ -11,7 +11,7 @@ We've documented all the data that feeds into the City of LA COVID-19 Dashboard 
 1. [Prior Updates to Workflow](#prior-updates-to-workflow)
 
 ## Data Sources
-* [City of LA COVID-19 Dashboard](http://lahub.maps.arcgis.com/apps/opsdashboard/index.html#/f1c6c7f54f964900aacfa6b76b99eb62) and [Mobile Version](http://lahub.maps.arcgis.com/home/item.html?id=e5b46ffbbf8b4f77ae2761b18abbd22c) and FAQs
+* [City of LA COVID-19 Dashboard](http://lahub.maps.arcgis.com/apps/opsdashboard/index.html#/f1c6c7f54f964900aacfa6b76b99eb62) and [Mobile Version](http://lahub.maps.arcgis.com/home/item.html?id=e5b46ffbbf8b4f77ae2761b18abbd22c) and [FAQs](https://docs.google.com/document/d/1U96_d1LTabeWl6uZv97ZEVKaKYse_UdebzO_6gAfNAc/)
 
 * [City of LA's COVID-19 GitHub repo and ETL](https://github.com/CityOfLosAngeles/aqueduct/tree/master/dags/public-health/covid19/). We welcome collaboration and pull requests on our work!
 

--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -2,7 +2,7 @@
 Pull data from MOPS COVID Dashboard and upload to ESRI
 """
 import datetime
-
+import pytz
 import arcgis
 import pandas as pd
 from airflow import DAG
@@ -17,7 +17,12 @@ def get_data(filename, workbook, sheet_name):
     df.reset_index(level=0, inplace=True)
     df.columns = ["Date", "Performed", "Test Kit Inventory"]
     df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
-    df = df.loc[df["Date"].dt.date < datetime.datetime.now().date()]
+    df = df.loc[
+        df["Date"].dt.date
+        < datetime.datetime.now()
+        .astimezone(pytz.timezone("America/Los_Angeles"))
+        .date()
+    ]
     df.sort_values("Date", inplace=True)
     cumulative = []
     temp_value = 0


### PR DESCRIPTION
The testing dag was supposed to only pull yesterday's data. However, it has been pulling today's data in the evening. I'm guessing because the system aqueduct is operating on is based on UTC instead of PDT.

I've localized the date the dataframe is compared to using pytz, which should hopefully fix the issue.