### PR TITLE
Fixing string issue for COVID testing dag

### DIFF
--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -30,6 +30,8 @@ def get_data(filename, workbook, sheet_name):
         temp_value += i
         cumulative.append(temp_value)
     df["Cumulative"] = cumulative
+    df["Performed"] = df["Performed"].astype(int)
+    df["Cumulative"] = df["Cumulative"].astype(int)
     df.to_csv("/tmp/%s" % filename, index=False)
 
 


### PR DESCRIPTION
Used `df[column].astype(int)` to fix the issue of AGOL converting the numeric columns to strings. I left the `Test Kit Inventory` field alone because MOPS is no longer updating that field.

Alternatively, I could create a new layer without that column if you prefer.