### PR TITLE
Standardize coordinates

### DIFF
--- a/dags/public-health/covid19/jhu-to-esri.py
+++ b/dags/public-health/covid19/jhu-to-esri.py
@@ -226,9 +226,22 @@ def load_global_covid_data():
 
     # Bring in the current date's JHU data
     today_df = load_jhu_global_current()
+    coordinates = today_df[
+        ["Province_State", "Country_Region", "Lat", "Long"]
+    ].drop_duplicates()
 
     # Append
     df = historical_df.append(today_df, sort=False)
+
+    # Merge in lat/lon coordinates
+    # There are differences between GitHub CSV and feature layer. Use feature layer's.
+    df = pd.merge(
+        df.drop(columns=["Lat", "Long"]),
+        coordinates,
+        on=["Province_State", "Country_Region"],
+        how="left",
+        validate="m:1",
+    )
 
     df = (
         df.assign(


### PR DESCRIPTION
* Standardize lat/lon because there are slight differences coming from JHU's GitHub and JHU's feature layer. Use feature layer's version of lat/lon because it has more decimal places than the CSV.