### PR TITLE
New COVID-19 testing feature layer with LA County and City broken out

### DIFF
--- a/dags/public-health/covid19/README.md
+++ b/dags/public-health/covid19/README.md
@@ -47,7 +47,9 @@ We've documented all the data that feeds into the City of LA COVID-19 Dashboard 
 * Hospital bed and equipment availability [feature layer](http://lahub.maps.arcgis.com/home/item.html?id=956e105f422a4c1ba9ce5d215b835951) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=3da1eb3e13a14743973c96b945bd1117)
 
 #### COVID-19 Testing
-* City of LA COVID-19 tests administered [feature layer](https://lahub.maps.arcgis.com/home/item.html?id=64b91665fef4471dafb6b2ff98daee6c) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=158dab4a07b04ecb8d47fea1746303ac)
+* LA County COVID-19 tests administered [feature layer](https://lahub.maps.arcgis.com/home/item.html?id=64b91665fef4471dafb6b2ff98daee6c) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=158dab4a07b04ecb8d47fea1746303ac)
+
+* LA County and LA City COVID-19 tests administered [feature layer](https://lahub.maps.arcgis.com/home/item.html?id=c33bb1acc0f4484ba7eaddd5f3e6c8e7) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=1eec9fe85f60447792644078d0a0d050)
 
 * The relevant script is to transform testing data is: `sync-covid-testing-data.py`.
 

--- a/dags/public-health/covid19/README.md
+++ b/dags/public-health/covid19/README.md
@@ -49,7 +49,7 @@ We've documented all the data that feeds into the City of LA COVID-19 Dashboard 
 #### COVID-19 Testing
 * LA County COVID-19 tests administered [feature layer](https://lahub.maps.arcgis.com/home/item.html?id=64b91665fef4471dafb6b2ff98daee6c) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=158dab4a07b04ecb8d47fea1746303ac)
 
-* LA County and LA City COVID-19 tests administered [feature layer](https://lahub.maps.arcgis.com/home/item.html?id=c33bb1acc0f4484ba7eaddd5f3e6c8e7) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=1eec9fe85f60447792644078d0a0d050)
+* LA County and LA City COVID-19 tests administered [feature layer](https://lahub.maps.arcgis.com/home/item.html?id=996a863e59f04efdbe33206a6c717afb) and [CSV](https://lahub.maps.arcgis.com/home/item.html?id=3cfd003985b447c994a7252e8eb97b92).
 
 * The relevant script is to transform testing data is: `sync-covid-testing-data.py`.
 
@@ -105,6 +105,8 @@ LA County issues a [daily HavBed pdf survey](http://file.lacounty.gov/SDSInter/d
 
 ## Testing Data
 The City collects data on the number of tests performed and test kits available from its several COVID-19 testing sites. The DAG `sync-covid-testing-data.py` syncs the data from a [Google spreadsheet](https://docs.google.com/spreadsheets/d/1agPpAJ5VNqpY50u9RhcPOu7P54AS0NUZhvA2Elmp2m4/edit?usp=sharing) with our ESRI feature layer. Our ESRI map layers are public and listed in the [Data Sources section](#data-sources).
+
+The City of LA tests are a subset of LA County tests. Tests done in other parts of LA County (excluding the City of LA) would be derived by taking the difference of `Performed` - `City_Performed`.
 
 
 ## Prior Updates to Workflow

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -432,7 +432,7 @@ def append_county_time_series(**kwargs):
     # (7) Write to CSV and overwrite the old feature layer.
     time_series_filename = "/tmp/jhu-county-time-series.csv"
     final.to_csv(time_series_filename)
-    final.to_parquet(f"s3://{bucket_name}/jhu_covid19/us-county-time-series.parquet")
+    # final.to_parquet(f"s3://{bucket_name}/jhu_covid19/us-county-time-series.parquet")
     gis_item = gis.content.get(TIME_SERIES_FEATURE_ID)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
     gis_layer_collection.manager.overwrite(time_series_filename)

--- a/dags/public-health/covid19/jhu-county-to-esri.py
+++ b/dags/public-health/covid19/jhu-county-to-esri.py
@@ -13,6 +13,8 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
 from arcgis.gis import GIS
 
+bucket_name = "public-health-dashboard"
+
 # URL to JHU confirmed cases US county time series.
 CASES_URL = (
     "https://github.com/CSSEGISandData/COVID-19/raw/{}/"
@@ -430,6 +432,7 @@ def append_county_time_series(**kwargs):
     # (7) Write to CSV and overwrite the old feature layer.
     time_series_filename = "/tmp/jhu-county-time-series.csv"
     final.to_csv(time_series_filename)
+    final.to_parquet(f"s3://{bucket_name}/jhu_covid19/us-county-time-series.parquet")
     gis_item = gis.content.get(TIME_SERIES_FEATURE_ID)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
     gis_layer_collection.manager.overwrite(time_series_filename)

--- a/dags/public-health/covid19/jhu-to-esri.py
+++ b/dags/public-health/covid19/jhu-to-esri.py
@@ -13,6 +13,7 @@ from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
 from arcgis.gis import GIS
 
+bucket_name = "public-health-dashboard"
 
 # URL to JHU confirmed cases time series.
 CASES_URL = (
@@ -258,6 +259,7 @@ def load_global_covid_data():
     # Output to CSV
     time_series_filename = "/tmp/jhu_covid19_time_series.csv"
     df.to_csv(time_series_filename, index=False)
+    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/global-time-series.parquet")
 
     # Also output the most current date as a separate CSV for convenience
     most_recent_date_filename = "/tmp/jhu_covid19_current.csv"

--- a/dags/public-health/covid19/sync-bed-availability-data.py
+++ b/dags/public-health/covid19/sync-bed-availability-data.py
@@ -15,7 +15,7 @@ bucket_name = "public-health-dashboard"
 def get_data(filename, workbook):
     df = pd.read_csv(workbook)
     df.to_csv(filename, index=False)
-    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/hospital-availability.parquet")
+    # df.to_parquet(f"s3://{bucket_name}/jhu_covid19/hospital-availability.parquet")
 
 
 def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):

--- a/dags/public-health/covid19/sync-bed-availability-data.py
+++ b/dags/public-health/covid19/sync-bed-availability-data.py
@@ -9,10 +9,13 @@ from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
 
+bucket_name = "public-health-dashboard"
+
 
 def get_data(filename, workbook):
     df = pd.read_csv(workbook)
     df.to_csv(filename, index=False)
+    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/hospital-availability.parquet")
 
 
 def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):

--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -1,7 +1,8 @@
 """
-Pull data from MOPS COVID Dashboard and upload to ESRI
+Pull data from MOPS COVID Dashboard and upload to ESRI.
 """
 import datetime
+import os
 import pytz
 import arcgis
 import pandas as pd
@@ -9,38 +10,117 @@ from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
 
+# County totals
+LA_COUNTY_TESTS_FEATURE_ID = "64b91665fef4471dafb6b2ff98daee6c"
+# City and county totals
+LA_CITY_TESTS_FEATURE_ID = "c33bb1acc0f4484ba7eaddd5f3e6c8e7"
 
-def get_data(filename, workbook, sheet_name):
+"""
+t1 - County totals
+"""
+
+
+def get_county_data(filename, workbook, sheet_name):
     df = pd.read_excel(workbook, sheet_name=sheet_name, skiprows=1, index_col=0)
     df = df.T
-    df = df.iloc[:, 1:3]
+
+    select_rows = [1, 2, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+    df = df.iloc[:, select_rows]
+
     df.reset_index(level=0, inplace=True)
-    df.columns = ["Date", "Performed", "Test Kit Inventory"]
+
+    column_names = [
+        "Date",
+        "Performed",
+        "Test Kit Inventory",
+        "Hotkin_Memorial",
+        "Hansen_Dam",
+        "Crenshaw_Christian",
+        "VA_Lot15",
+        "Lincoln_Park",
+        "West_Valley_Warner",
+        "Carbon_Health_Echo_Park",
+        "Kedren_Health",
+        "Baldwin_Hills_Crenshaw",
+        "Northridge_Fashion",
+        "Nursing_Home_Outreach",
+        "Homeless_Outreach",
+    ]
+
+    df.columns = column_names
+
     df["Date"] = pd.to_datetime(df["Date"], errors="coerce")
-    df = df.loc[
-        df["Date"].dt.date
+    df = df[
+        df.Date.dt.date
         < datetime.datetime.now()
         .astimezone(pytz.timezone("America/Los_Angeles"))
         .date()
+    ].sort_values("Date")
+
+    # Fill in missing values with 0's for city sites
+    city_sites = [
+        "Hotkin_Memorial",
+        "Hansen_Dam",
+        "Crenshaw_Christian",
+        "VA_Lot15",
+        "Lincoln_Park",
+        "West_Valley_Warner",
+        "Carbon_Health_Echo_Park",
+        "Kedren_Health",
+        "Baldwin_Hills_Crenshaw",
+        "Northridge_Fashion",
+        "Nursing_Home_Outreach",
+        "Homeless_Outreach",
     ]
-    df.sort_values("Date", inplace=True)
-    cumulative = []
-    temp_value = 0
-    for i in df["Performed"]:
-        temp_value += i
-        cumulative.append(temp_value)
-    df["Cumulative"] = cumulative
-    df["Performed"] = df["Performed"].astype(int)
-    df["Cumulative"] = df["Cumulative"].astype(int)
-    df.to_csv("/tmp/%s" % filename, index=False)
+
+    df[city_sites] = df[city_sites].fillna(0).astype(int)
+
+    df = df.assign(city_performed=df[city_sites].astype(int).sum(axis=1),)
+
+    # Calculate cumulative sums for whole county and city
+    keep_cols = ["Date", "Performed", "Cumulative", "City_Cumulative"]
+
+    df = df.assign(
+        Performed=df.Performed.astype(int),
+        Cumulative=df.sort_values("Date")["Performed"].cumsum().astype(int),
+        City_Cumulative=df.sort_values("Date")["city_performed"].cumsum().astype(int),
+    )[keep_cols].sort_values("Date")
+
+    df.drop(columns="City_Cumulative").to_csv("/tmp/county_cumulative.csv", index=False)
+
+    return df
 
 
-def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):
-    filename = "/tmp/%s" % filename
+def update_county_arcgis(arcuser, arcpassword, arcfeatureid, filename):
+    county_filename = "/tmp/county_cumulative.csv"
     gis = arcgis.GIS("http://lahub.maps.arcgis.com", arcuser, arcpassword)
-    gis_item = gis.content.get(arcfeatureid)
+    gis_item = gis.content.get(LA_COUNTY_TESTS_FEATURE_ID)
     gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
-    gis_layer_collection.manager.overwrite(filename)
+    gis_layer_collection.manager.overwrite(county_filename)
+
+    # Clean up
+    os.remove(county_filename)
+
+
+"""
+t2 - City and County Totals
+"""
+
+
+def get_city_data(filename, workbook, sheet_name):
+    df = get_county_data(filename, workbook, sheet_name)
+    df.to_csv("/tmp/city_county_cumulative.csv", index=False)
+
+
+def update_city_arcgis(arcuser, arcpassword, arcfeatureid, filename):
+    city_filename = "/tmp/city_county_cumulative.csv"
+    gis = arcgis.GIS("http://lahub.maps.arcgis.com", arcuser, arcpassword)
+    gis_item = gis.content.get(LA_CITY_TESTS_FEATURE_ID)
+    gis_layer_collection = arcgis.features.FeatureLayerCollection.fromitem(gis_item)
+    gis_layer_collection.manager.overwrite(city_filename)
+
+    # Clean up
+    os.remove(city_filename)
 
 
 default_args = {
@@ -73,14 +153,32 @@ def update_covid_testing_data(**kwargs):
     filename = kwargs.get("filename")
     workbook = kwargs.get("workbook")
     sheet_name = kwargs.get("sheet_name")
-    get_data(filename, workbook, sheet_name)
+    get_county_data(filename, workbook, sheet_name)
 
-    # Updating ArcGis
+    # Updating ArcGIS
     arcconnection = BaseHook.get_connection("arcgis")
     arcuser = arcconnection.login
     arcpassword = arcconnection.password
-    arcfeatureid = kwargs.get("arcfeatureid")
-    update_arcgis(arcuser, arcpassword, arcfeatureid, filename)
+    arcfeatureid = kwargs.get(LA_COUNTY_TESTS_FEATURE_ID)
+    update_county_arcgis(arcuser, arcpassword, arcfeatureid, filename)
+
+
+def update_covid_testing_city_county_data(**kwargs):
+    """
+    The actual python callable that Airflow schedules.
+    """
+    # Getting data from google sheet
+    filename = kwargs.get("filename")
+    workbook = kwargs.get("workbook")
+    sheet_name = kwargs.get("sheet_name")
+    get_county_data(filename, workbook, sheet_name)
+
+    # Updating ArcGIS
+    arcconnection = BaseHook.get_connection("arcgis")
+    arcuser = arcconnection.login
+    arcpassword = arcconnection.password
+    arcfeatureid = kwargs.get(LA_CITY_TESTS_FEATURE_ID)
+    update_county_arcgis(arcuser, arcpassword, arcfeatureid, filename)
 
 
 # Sync ServiceRequestData.csv
@@ -90,7 +188,7 @@ t1 = PythonOperator(
     python_callable=update_covid_testing_data,
     op_kwargs={
         "filename": "COVID_testing_data.csv",
-        "arcfeatureid": "64b91665fef4471dafb6b2ff98daee6c",
+        "arcfeatureid": LA_COUNTY_TESTS_FEATURE_ID,
         "workbook": "https://docs.google.com/spreadsheets/d/"
         "1agPpAJ5VNqpY50u9RhcPOu7P54AS0NUZhvA2Elmp2m4/"
         "export?format=xlsx&#gid=0",
@@ -98,3 +196,20 @@ t1 = PythonOperator(
     },
     dag=dag,
 )
+
+t2 = PythonOperator(
+    task_id="update_COVID_Testing_City_County_Data",
+    provide_context=True,
+    python_callable=update_covid_testing_city_county_data,
+    op_kwargs={
+        "filename": "COVID_testing_data.csv",
+        "arcfeatureid": LA_CITY_TESTS_FEATURE_ID,
+        "workbook": "https://docs.google.com/spreadsheets/d/"
+        "1agPpAJ5VNqpY50u9RhcPOu7P54AS0NUZhvA2Elmp2m4/"
+        "export?format=xlsx&#gid=0",
+        "sheet_name": "DUPLICATE OF MOPS",
+    },
+    dag=dag,
+)
+
+t1 > t2

--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -114,7 +114,7 @@ t2 - City and County Totals
 def get_city_data(filename, workbook, sheet_name):
     df = get_county_data(filename, workbook, sheet_name)
     df.to_csv("/tmp/city_county_cumulative.csv", index=False)
-    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/la-city-county-testing.parquet")
+    # df.to_parquet(f"s3://{bucket_name}/jhu_covid19/la-city-county-testing.parquet")
 
 
 def update_city_arcgis(arcuser, arcpassword, arcfeatureid, filename):

--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -15,6 +15,8 @@ LA_COUNTY_TESTS_FEATURE_ID = "64b91665fef4471dafb6b2ff98daee6c"
 # City and county totals
 LA_CITY_TESTS_FEATURE_ID = "c33bb1acc0f4484ba7eaddd5f3e6c8e7"
 
+bucket_name = "public-health-dashboard"
+
 """
 t1 - County totals
 """
@@ -110,6 +112,7 @@ t2 - City and County Totals
 def get_city_data(filename, workbook, sheet_name):
     df = get_county_data(filename, workbook, sheet_name)
     df.to_csv("/tmp/city_county_cumulative.csv", index=False)
+    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/la_city_county_testing.parquet")
 
 
 def update_city_arcgis(arcuser, arcpassword, arcfeatureid, filename):

--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -13,7 +13,7 @@ from airflow.operators.python_operator import PythonOperator
 # County totals
 LA_COUNTY_TESTS_FEATURE_ID = "64b91665fef4471dafb6b2ff98daee6c"
 # City and county totals
-LA_CITY_TESTS_FEATURE_ID = "c33bb1acc0f4484ba7eaddd5f3e6c8e7"
+LA_CITY_TESTS_FEATURE_ID = "996a863e59f04efdbe33206a6c717afb"
 
 bucket_name = "public-health-dashboard"
 
@@ -77,18 +77,20 @@ def get_county_data(filename, workbook, sheet_name):
 
     df[city_sites] = df[city_sites].fillna(0).astype(int)
 
-    df = df.assign(city_performed=df[city_sites].astype(int).sum(axis=1),)
+    df = df.assign(City_performed=df[city_sites].astype(int).sum(axis=1),)
 
     # Calculate cumulative sums for whole county and city
-    keep_cols = ["Date", "Performed", "Cumulative", "City_Cumulative"]
+    keep_cols = ["Date", "Performed", "Cumulative", "City_Performed", "City_Cumulative"]
 
     df = df.assign(
         Performed=df.Performed.astype(int),
         Cumulative=df.sort_values("Date")["Performed"].cumsum().astype(int),
-        City_Cumulative=df.sort_values("Date")["city_performed"].cumsum().astype(int),
+        City_Cumulative=df.sort_values("Date")["City_performed"].cumsum().astype(int),
     )[keep_cols].sort_values("Date")
 
-    df.drop(columns="City_Cumulative").to_csv("/tmp/county_cumulative.csv", index=False)
+    df.drop(columns=["City_Performed", "City_Cumulative"]).to_csv(
+        "/tmp/county_cumulative.csv", index=False
+    )
 
     return df
 

--- a/dags/public-health/covid19/sync-covid-testing-data.py
+++ b/dags/public-health/covid19/sync-covid-testing-data.py
@@ -112,7 +112,7 @@ t2 - City and County Totals
 def get_city_data(filename, workbook, sheet_name):
     df = get_county_data(filename, workbook, sheet_name)
     df.to_csv("/tmp/city_county_cumulative.csv", index=False)
-    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/la_city_county_testing.parquet")
+    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/la-city-county-testing.parquet")
 
 
 def update_city_arcgis(arcuser, arcpassword, arcfeatureid, filename):

--- a/dags/public-health/covid19/sync-la-cases-data.py
+++ b/dags/public-health/covid19/sync-la-cases-data.py
@@ -20,7 +20,7 @@ def get_data(filename, workbook, sheet_name):
     df["City of LA Cases"] = df["City of LA Cases"].astype(int)
     df["City of LA New Cases"] = df["City of LA New Cases"].astype(int)
     df.to_csv(filename, index=False)
-    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/city-of-la-cases.parquet")
+    # df.to_parquet(f"s3://{bucket_name}/jhu_covid19/city-of-la-cases.parquet")
 
 
 def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):

--- a/dags/public-health/covid19/sync-la-cases-data.py
+++ b/dags/public-health/covid19/sync-la-cases-data.py
@@ -8,6 +8,8 @@ from airflow import DAG
 from airflow.hooks.base_hook import BaseHook
 from airflow.operators.python_operator import PythonOperator
 
+bucket_name = "public-health-dashboard"
+
 
 def get_data(filename, workbook, sheet_name):
     df = pd.read_excel(workbook, sheet_name=sheet_name)
@@ -18,6 +20,7 @@ def get_data(filename, workbook, sheet_name):
     df["City of LA Cases"] = df["City of LA Cases"].astype(int)
     df["City of LA New Cases"] = df["City of LA New Cases"].astype(int)
     df.to_csv(filename, index=False)
+    df.to_parquet(f"s3://{bucket_name}/jhu_covid19/city-of-la-cases.parquet")
 
 
 def update_arcgis(arcuser, arcpassword, arcfeatureid, filename):


### PR DESCRIPTION
* Update DAG so that we have a new layer with LA county and City of LA tests administered
* Original layer will still be updated -- need to update dashboard and README to clarify it's "LA County", not "City of LA"
* But, we will still be interested in City of LA tests administered, so let's create a layer with that, but also keep the county column intact. Won't need to swap out layers, but let's consolidate the information to be in 1 new layer so it's easier to use.
* Update README
* Add a parquet export to all the DAGs and save parquet to S3

Ref: [GH issue](https://github.com/CityOfLosAngeles/covid19-indicators/issues/4)