### PR TITLE
Also install airflow requirements on deploy. 

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -14,4 +14,5 @@ if command -v pyenv 1>/dev/null 2>&1; then
 
 export SLUGIFY_USES_TEXT_UNIDECODE=yes
 echo `which pip`
+/home/ec2-user/.pyenv/shims/pip install --user -r /home/ec2-user/aqueduct/airflow-requirements.txt
 /home/ec2-user/.pyenv/shims/pip install --user -r /home/ec2-user/aqueduct/requirements.txt


### PR DESCRIPTION
We had stopped doing this since we don't want uncontrolled upgrades. For instance, we had a problem last year where an inadvertent upgrade to airflow forced an unexpected db migration. But as long as we keep the version numbers pinned in the airflow-requirements.txt, this should be safe. This makes it so that the versions of airflow match on newly scaled-up nodes in the autoscaling group.