### PR TITLE
Voila

### DIFF
--- a/civis/Dockerfile
+++ b/civis/Dockerfile
@@ -131,4 +131,6 @@ RUN echo `which jupyter-lab`
 EXPOSE 8888
 WORKDIR /root/work
 ENTRYPOINT ["/tini", "--"]
-CMD ["civis-jupyter-notebooks-start"]
+
+# CMD ["civis-jupyter-notebooks-start"]
+CMD ["voila", "--port=3838", "--Voila.ip='*'", "--no-browser", "--Voila.tornado_settings={\"headers\":{\"Content-Security-Policy\":\"frame-ancestors platform.civisanalytics.com localhost:*; report-uri /api/security/csp-report\" }}","/app"]

--- a/civis/Dockerfile
+++ b/civis/Dockerfile
@@ -132,6 +132,11 @@ EXPOSE 8888
 WORKDIR /root/work
 ENTRYPOINT ["/tini", "--"]
 
+# Copy the aws-configure script
+COPY aws-configure /usr/local/bin/
+RUN chmod +x /usr/local/bin/aws-configure
+
+# Copy the start script
 COPY start.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start.sh
 

--- a/civis/Dockerfile
+++ b/civis/Dockerfile
@@ -132,5 +132,7 @@ EXPOSE 8888
 WORKDIR /root/work
 ENTRYPOINT ["/tini", "--"]
 
-# CMD ["civis-jupyter-notebooks-start"]
-CMD ["voila", "--port=3838", "--Voila.ip='*'", "--no-browser", "--Voila.tornado_settings={\"headers\":{\"Content-Security-Policy\":\"frame-ancestors platform.civisanalytics.com localhost:*; report-uri /api/security/csp-report\" }}","/app"]
+COPY start.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/start.sh
+
+CMD ["start.sh"]

--- a/civis/aws-configure
+++ b/civis/aws-configure
@@ -1,0 +1,13 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+
+if not os.environ.get("AWS_ACCESS_KEY_ID") and not os.environ.get(
+    "AWS_SECRET_ACCESS_KEY"
+):
+    for key, value in os.environ.items():
+        if "AWS" in key and key.endswith("_USERNAME"):
+            subprocess.run(["aws", "configure", "set", "aws_access_key_id", value])
+        if "AWS" in key and key.endswith("_PASSWORD"):
+            subprocess.run(["aws", "configure", "set", "aws_secret_access_key", value])

--- a/civis/aws-configure
+++ b/civis/aws-configure
@@ -3,11 +3,41 @@
 import os
 import subprocess
 
+import civis
+
+# Only try to configure if the AWS env variables are not otherwise set.
 if not os.environ.get("AWS_ACCESS_KEY_ID") and not os.environ.get(
     "AWS_SECRET_ACCESS_KEY"
 ):
-    for key, value in os.environ.items():
-        if "AWS" in key and key.endswith("_USERNAME"):
-            subprocess.run(["aws", "configure", "set", "aws_access_key_id", value])
-        if "AWS" in key and key.endswith("_PASSWORD"):
-            subprocess.run(["aws", "configure", "set", "aws_secret_access_key", value])
+    if os.environ.get("CIVIS_API_KEY"):
+        # If a CIVIS_API_KEY is present, we can check for credentials
+        # that actually are marked as having an AWS type.
+        client = civis.APIClient()
+        credentials = client.credentials.list()
+        for credential in credentials:
+            if "Amazon Web Services" in credential["type"]:
+                prefix = credential["name"].upper()
+                username = os.environ.get(f"{prefix}_USERNAME", "")
+                password = os.environ.get(f"{prefix}_PASSWORD", "")
+                if username and password:
+                    print(f"Configuring AWS with credential {prefix}")
+                    subprocess.run(
+                        ["aws", "configure", "set", "aws_access_key_id", username]
+                    )
+                    subprocess.run(
+                        ["aws", "configure", "set", "aws_secret_access_key", password]
+                    )
+                    break
+        else:
+            print("Unable to find AWS credentials in environment")
+    else:
+        # If no CIVIS_API_KEY is present, look for credentials that have AWS in the
+        # name. This is less reliable, but and should be considered a hack.
+        for key, value in os.environ.items():
+            if "AWS" in key and key.endswith("_USERNAME"):
+                print(f"Configuring AWS with credential {key}")
+                subprocess.run(["aws", "configure", "set", "aws_access_key_id", value])
+            if "AWS" in key and key.endswith("_PASSWORD"):
+                subprocess.run(
+                    ["aws", "configure", "set", "aws_secret_access_key", value]
+                )

--- a/civis/docker-compose.yml
+++ b/civis/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       - CIVIS_SERVICE_ID=1
       - MY_AWS_USERNAME=${AWS_ACCESS_KEY_ID}
       - MY_AWS_PASSWORD=${AWS_SECRET_ACCESS_KEY}
+      - REPO_PATH_DIR=${REPO_PATH_DIR}
   # Use the official postgis image for postgres
   postgres:
     image: mdillon/postgis:9.6

--- a/civis/docker-compose.yml
+++ b/civis/docker-compose.yml
@@ -25,6 +25,8 @@ services:
     environment:
       - DEV=1
       - CIVIS_SERVICE_ID=1
+      - MY_AWS_USERNAME=${AWS_ACCESS_KEY_ID}
+      - MY_AWS_PASSWORD=${AWS_SECRET_ACCESS_KEY}
   # Use the official postgis image for postgres
   postgres:
     image: mdillon/postgis:9.6

--- a/civis/docker-compose.yml
+++ b/civis/docker-compose.yml
@@ -14,6 +14,17 @@ services:
       - POSTGRES_URI=postgres://ita:secret@postgres:5432/ita
       - REDSHIFT_URI=postgres://ita:secret@redshift:5432/ita
     command: "jupyter-lab --no-browser --ip=\"*\" --allow-root --port=8888 --NotebookApp.notebook_dir=/app --NotebookApp.terminado_settings='{\"shell_command\": [\"bash\"]}' --LabApp.token=\"\" --LabApp.password=\"\""
+  civis-voila:
+    build: ./
+    image: civis-voila
+    container_name: civis-voila
+    volumes:
+     - ../:/app
+    ports:
+      - "3838:3838"
+    environment:
+      - DEV=1
+      - CIVIS_SERVICE_ID=1
   # Use the official postgis image for postgres
   postgres:
     image: mdillon/postgis:9.6

--- a/civis/start.sh
+++ b/civis/start.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ -z $CIVIS_SERVICE_ID ]]; then
+    civis-jupyter-notebooks-start
+else
+    voila \
+        --port=3838 \
+        --no-browser \
+        --Voila.ip='*' \
+        --Voila.tornado_settings=$'{"headers":{"Content-Security-Policy":"frame-ancestors platform.civisanalytics.com localhost:*; report-uri /api/security/csp-report" }}' \
+        /app
+fi

--- a/civis/start.sh
+++ b/civis/start.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Run the aws-configure script to try to detect AWS credentials from the environment
+aws-configure
+
+# Test if CIVIS_SERVICE_ID is defined. If so, we are likely in a deployed
+# service, so start voila. If not, we are likely in a Civis Jupyter notebook
+# context, so start that.
 if [[ -z $CIVIS_SERVICE_ID ]]; then
     civis-jupyter-notebooks-start
 else

--- a/civis/start.sh
+++ b/civis/start.sh
@@ -14,5 +14,5 @@ else
         --no-browser \
         --Voila.ip='*' \
         --Voila.tornado_settings=$'{"headers":{"Content-Security-Policy":"frame-ancestors platform.civisanalytics.com localhost:*; report-uri /api/security/csp-report" }}' \
-        /app
+        ${APP_DIR:-/app}/${REPO_PATH_DIR}
 fi

--- a/civis/start.sh
+++ b/civis/start.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Run the aws-configure script to try to detect AWS credentials from the environment
-aws-configure
+aws-configure || true
 
 # Test if CIVIS_SERVICE_ID is defined. If so, we are likely in a deployed
 # service, so start voila. If not, we are likely in a Civis Jupyter notebook


### PR DESCRIPTION
This adds support for deploying voila as a Civis service using the `citywide-civis-lab` docker image.

It does a few things:
1. Detects whether we are in a Civis Jupyter Notebook setting or a Civis Service setting. If the former, starts the notebook server. If the latter, starts voila.
1. Sets Content-Security-Policies on voila that allows it to be iframe'd in the civis platform.
1. Uses the Civis Python client in the dockerfile start script to try to detect if an AWS credential is attached to the container. If one is found, it auto-configures the AWS cli on the system to use that.