### PR TITLE
Util package

### DIFF
--- a/civis/Dockerfile
+++ b/civis/Dockerfile
@@ -113,15 +113,12 @@ RUN jupyter lab build --dev-build=False --debug && jupyter lab clean
 
 # Civis-related
 ENV DEFAULT_KERNEL python3
-# civis-jupyter-notebook is heavy handed with depenencies.
+# civis-jupyter-notebook is heavy handed with dependencies.
 # If we want a different version of pandas, we have to reinstall it afterwards.
 RUN pip install civis-jupyter-notebook && \
      civis-jupyter-notebooks-install && \
      pip install -U pandas
 
-# Environment-related
-COPY custom.sh /tmp/custom.sh
-RUN cat /tmp/custom.sh >> /root/.bashrc
 
 ENV TINI_VERSION v0.16.1
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
@@ -131,6 +128,17 @@ RUN echo `which jupyter-lab`
 EXPOSE 8888
 WORKDIR /root/work
 ENTRYPOINT ["/tini", "--"]
+
+# Install the local utils package
+COPY civis-aqueduct-utils /tmp/civis-aqueduct-utils
+RUN pip install /tmp/civis-aqueduct-utils && \
+      jupyter nbextension install --sys-prefix --py civis_aqueduct_utils && \
+      jupyter nbextension enable --sys-prefix --py civis_aqueduct_utils && \
+      rm -r /tmp/civis-aqueduct-utils
+
+# Environment-related
+COPY custom.sh /tmp/custom.sh
+RUN cat /tmp/custom.sh >> /root/.bashrc
 
 # Copy the aws-configure script
 COPY aws-configure /usr/local/bin/

--- a/civis/README.md
+++ b/civis/README.md
@@ -155,6 +155,13 @@ You can do this with the following steps:
 1. Specify the credentials needed by setting parameters for the script. For instance, you might need to add "Database" and "AWS" credentials. Once the parameters have been set up, you can populate them with specific values.
 1. Optionally schedule the job by clicking the "Automate" button.
 
+## Sharing a service
+
+Civis allows you to run a Docker image as a service, which could be a dashboard,
+a report, or a deployed app/model. You may want to share a link to that service
+with an external stakeholder. In order to do this, you can follow the directions
+given [here](./civis-aqueduct-utils/README.md).
+
 ## Publishing the image
 
 The [Dockerfile](./Dockerfile) in this repository is intended to be a convenient

--- a/civis/civis-aqueduct-utils/README.md
+++ b/civis/civis-aqueduct-utils/README.md
@@ -1,3 +1,40 @@
 # Civis-Aqueduct Utils
 
 A small Python module containing utilities for working with Civis and Aqueduct.
+
+## Installation
+
+To install, enter
+```bash
+pip install .
+```
+in your terminal from this directory.
+
+## JupyterLab extension
+
+This adds a small button to the toolbar of the classic Jupyter Notebook to launch JupyterLab,
+allowing users to toggle back and forth between environments when using a Jupyter notebook
+server in the Civis platform.
+
+## Civis-Service CLI
+
+This small CLI tool allows Civis platform users to generate shareable URLs to a deployed service.
+This URL can then be shared with external stakeholders to view reports, dashboards, etc.
+
+To list available services, enter
+```bash
+civis-service list
+```
+
+To share a service, enter
+```bash
+civis-service share SERVICE_ID SHARE_NAME
+```
+where `SERVICE_ID` is the integer ID of the service, and `SHARE_NAME` is a unique name
+for the share link that is generated. You can only use a `SHARE_NAME` once, new
+URLs must have a different name.
+
+To unshare a URL that you have created so that it no longer works, enter
+```bash
+civis-service unshare SERVICE_ID SHARE_NAME
+```

--- a/civis/civis-aqueduct-utils/README.md
+++ b/civis/civis-aqueduct-utils/README.md
@@ -1,0 +1,3 @@
+# Civis-Aqueduct Utils
+
+A small Python module containing utilities for working with Civis and Aqueduct.

--- a/civis/civis-aqueduct-utils/civis_aqueduct_utils/__init__.py
+++ b/civis/civis-aqueduct-utils/civis_aqueduct_utils/__init__.py
@@ -1,0 +1,9 @@
+def _jupyter_nbextension_paths():
+    return [
+        {
+            "section": "notebook",
+            "src": "static",
+            "dest": "civis_aqueduct_utils",
+            "require": "civis_aqueduct_utils/extension",
+        }
+    ]

--- a/civis/civis-aqueduct-utils/civis_aqueduct_utils/share.py
+++ b/civis/civis-aqueduct-utils/civis_aqueduct_utils/share.py
@@ -1,0 +1,69 @@
+"""
+Small utility for creating shareable links to Civis services.
+"""
+import argparse
+
+import civis
+
+
+def list_services(args):
+    client = civis.APIClient()
+    services = client.services.list()
+    print("List of services:")
+    for service in services:
+        print(f"\tID: {service['id']}\tName: {service['name']}")
+
+
+def share_service(args):
+    client = civis.APIClient()
+    service = client.services.get(args.id)
+    try:
+        response = client.services.post_tokens(args.id, args.name)
+        url = f"{service['current_url']}/civis-platform-auth?token={response['token']}"
+        print(f"Share service id {args.id} with the following URL: {url}")
+    except civis.base.CivisAPIError as e:
+        if "Name has already been taken" in str(e):
+            print(
+                f"The share name {args.name} is already in use. "
+                "Please choose another"
+            )
+        else:
+            raise e
+
+
+def unshare_service(args):
+    client = civis.APIClient()
+    tokens = client.services.list_tokens(args.id)
+    try:
+        token = next(t for t in tokens if t["name"] == args.name)
+        client.services.delete_tokens(args.id, token["id"])
+        print(f"Successfully unshared {args.name}")
+    except StopIteration:
+        print(f"Could not find share token with the name {args.name}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers()
+
+    list_parser = subparsers.add_parser("list")
+    list_parser.set_defaults(func=list_services)
+
+    share_parser = subparsers.add_parser("share")
+    share_parser.add_argument("id", type=int, help="The ID of the service to share")
+    share_parser.add_argument("name", type=str, help="A name to give the share URL")
+    share_parser.set_defaults(func=share_service)
+
+    unshare_parser = subparsers.add_parser("unshare")
+    unshare_parser.add_argument("id", type=int, help="The ID of the service to unshare")
+    unshare_parser.add_argument(
+        "name", type=str, help="The name of the service to unshare"
+    )
+    unshare_parser.set_defaults(func=unshare_service)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/civis/civis-aqueduct-utils/civis_aqueduct_utils/static/extension.js
+++ b/civis/civis-aqueduct-utils/civis_aqueduct_utils/static/extension.js
@@ -10,8 +10,8 @@ define(['jquery', 'base/js/namespace'], function($, Jupyter) {
     "use strict";
     var open_lab = function() {
         Jupyter.notebook.save_notebook().then(function () {
-            let voila_url = Jupyter.notebook.base_url + "lab/tree/" + Jupyter.notebook.notebook_path;
-            window.open(voila_url)
+            let lab_url = Jupyter.notebook.base_url + "lab/tree/" + Jupyter.notebook.notebook_path;
+            window.location.href = lab_url
         });
     }
     var load_ipython_extension = function() {

--- a/civis/civis-aqueduct-utils/civis_aqueduct_utils/static/extension.js
+++ b/civis/civis-aqueduct-utils/civis_aqueduct_utils/static/extension.js
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2020 City of Los Angeles
+ *
+ * Distributed under the terms of the Apache 2.0 License.
+ *
+ * The full license is in the file LICENSE, distributed with this software.
+ */
+
+define(['jquery', 'base/js/namespace'], function($, Jupyter) {
+    "use strict";
+    var open_lab = function() {
+        Jupyter.notebook.save_notebook().then(function () {
+            let voila_url = Jupyter.notebook.base_url + "lab/tree/" + Jupyter.notebook.notebook_path;
+            window.open(voila_url)
+        });
+    }
+    var load_ipython_extension = function() {
+        Jupyter.toolbar.add_buttons_group([{
+            id : 'toggle_codecells',
+            label : 'JupyterLab',
+            icon : 'fa-desktop',
+            callback : open_lab,
+        }]);
+    };
+    return {
+        load_ipython_extension : load_ipython_extension
+    };
+});

--- a/civis/civis-aqueduct-utils/setup.py
+++ b/civis/civis-aqueduct-utils/setup.py
@@ -1,0 +1,16 @@
+from setuptools import find_packages, setup
+
+setup(
+    name="civis-aqueduct-utils",
+    version="0.1.0",
+    packages=find_packages(),
+    package_dir={"civis-aqueduct-utils": "civis-aqueduct-utils"},
+    include_package_data=True,
+    install_requires=["civis"],
+    data_files=[
+        (
+            "share/jupyter/nbextensions/civis-aqueduct-utils",
+            ["civis_aqueduct_utils/static/extension.js"],
+        ),
+    ],
+)

--- a/civis/civis-aqueduct-utils/setup.py
+++ b/civis/civis-aqueduct-utils/setup.py
@@ -13,4 +13,7 @@ setup(
             ["civis_aqueduct_utils/static/extension.js"],
         ),
     ],
+    entry_points={
+        "console_scripts": ["civis-service = civis_aqueduct_utils.share:main"]
+    },
 )


### PR DESCRIPTION
This adds the skeleton of a utility package for aqueduct-related python code. The idea is if we have commonly used code snippets that need to be imported across a number of jobs, having them in a centrally installed python package is nicer to work with than munging about with `sys.path` or similar.

It's mostly empty at the moment, except that I have added a somewhat self-serving nbextension that allows notebook users to open JupyterLab in a new tab if they prefer.